### PR TITLE
Update Nexus3 version

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,7 +1,7 @@
 require 'chefspec'
 require 'chefspec/berkshelf'
 
-VER = '3.2.1-01'.freeze
+VER = '3.3.1-01'.freeze
 CACHE = Chef::Config[:file_cache_path]
 
 ChefSpec::Coverage.start!


### PR DESCRIPTION
This is currently hardcoded and RSpec tests break whenever a new version of
Nexus is released. A proper fix should come later (see #2).