### PR TITLE
Add a basic library to query the Nexus API

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,6 +4,7 @@ gem 'berkshelf'
 gem 'chef', '~> 12.0'
 gem 'chefspec'
 gem 'foodcritic'
+gem 'webmock'
 
 group :integration do
   gem 'kitchen-dokken'

--- a/libraries/api.rb
+++ b/libraries/api.rb
@@ -5,8 +5,8 @@ module Nexus3
     def initialize(base_url, user, password)
       @http_client = HTTPClient.new(base_url: base_url).tap do |client|
         # Authentication
-        client.set_auth(nil, user, password)
-        client.force_basic_auth
+        client.set_auth(base_url, user, password)
+        client.force_basic_auth=true
         # Debugging
         client.debug_dev = STDOUT if ::Chef::Log.debug? || (ENV['HTTPCLIENT_LOG'] == 'stdout')
       end
@@ -27,7 +27,7 @@ module Nexus3
 
     # Query Nexus3 API for list of repos, returns struct (parsed JSON)
     def list_repositories
-      JSON.parse(request(:get, @url))
+      JSON.parse(request(:get, ''))
     end
   end
 end

--- a/libraries/api.rb
+++ b/libraries/api.rb
@@ -1,4 +1,5 @@
 module Nexus3
+  # Interact with the Nexus3 API
   class Api
     require 'json'
 
@@ -6,7 +7,7 @@ module Nexus3
       @http_client = HTTPClient.new(base_url: base_url).tap do |client|
         # Authentication
         client.set_auth(base_url, user, password)
-        client.force_basic_auth=true
+        client.force_basic_auth = true
         # Debugging
         client.debug_dev = STDOUT if ::Chef::Log.debug? || (ENV['HTTPCLIENT_LOG'] == 'stdout')
       end

--- a/libraries/api.rb
+++ b/libraries/api.rb
@@ -2,14 +2,14 @@ module Nexus3
   class Api
     require 'json'
 
-    def initialize(url, user, password)
-      @http_client = HTTPClient.new(url).tap do |client|
+    def initialize(base_url, user, password)
+      @http_client = HTTPClient.new(base_url: base_url).tap do |client|
         # Authentication
         client.set_auth(nil, user, password)
+        client.force_basic_auth
         # Debugging
         client.debug_dev = STDOUT if ::Chef::Log.debug? || (ENV['HTTPCLIENT_LOG'] == 'stdout')
       end
-      @url = url
     end
 
     attr_reader :http_client

--- a/libraries/api.rb
+++ b/libraries/api.rb
@@ -1,0 +1,33 @@
+module Nexus3
+  class Api
+    require 'json'
+
+    def initialize(url, user, password)
+      @http_client = HTTPClient.new(url).tap do |client|
+        # Authentication
+        client.set_auth(nil, user, password)
+        # Debugging
+        client.debug_dev = STDOUT if ::Chef::Log.debug? || (ENV['HTTPCLIENT_LOG'] == 'stdout')
+      end
+      @url = url
+    end
+
+    attr_reader :http_client
+
+    def request(method, path, data = nil)
+      response = http_client.request(method, path, data)
+
+      raise "HTTP_STATUS=#{response.status_code}#{response.body}" unless response.ok?
+
+      @response = response.body
+    rescue => e
+      error_message = " with following error\n#{e.response.body}" if e.respond_to? 'response'
+      raise "Nexus API: '#{e}' #{error_message}"
+    end
+
+    # Query Nexus3 API for list of repos, returns struct (parsed JSON)
+    def list_repositories
+      JSON.parse(request(:get, @url))
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,7 +1,15 @@
 require 'chefspec'
 require 'chefspec/berkshelf'
+require 'json'
+require 'webmock/rspec'
+
+WebMock.allow_net_connect!
 
 VER = '3.3.1-01'.freeze
 CACHE = Chef::Config[:file_cache_path]
+
+def json_response(result)
+  JSON.generate(result)
+end
 
 ChefSpec::Coverage.start!

--- a/spec/unit/libraries/api_spec.rb
+++ b/spec/unit/libraries/api_spec.rb
@@ -30,6 +30,7 @@ describe 'Nexus3::Api' do
       # TODO: if we add the Authorization header, the test fails, so
       # it may mean that the api http_client does not send the header.
       stub_request(:get, 'http://localhost/sample/api')
+        .with(basic_auth: ['admin', 'admin123'])
         .to_return(body: json_response(repo_list), headers: { 'Content-Type' => 'application/json' })
 
       expect(api_client.list_repositories).to eq(repo_list)

--- a/spec/unit/libraries/api_spec.rb
+++ b/spec/unit/libraries/api_spec.rb
@@ -1,0 +1,44 @@
+# coding: utf-8
+require_relative '../../spec_helper'
+
+describe 'Nexus3::Api' do
+  let(:api_client) do
+    Nexus3::Api.new('http://localhost/sample/api', 'admin', 'admin123')
+  end
+
+  let(:repo_list) do
+    [
+      {
+        'name' => 'foo',
+        'content' => 'repository.createMavenHosted(\'foo\')',
+        'type' => 'groovy',
+      },
+      {
+        'name' => 'anonymous',
+        'content' => 'security.setAnonymousAccess(Boolean.valueOf(args))',
+        'type' => 'groovy',
+      },
+    ]
+  end
+
+  before(:each) do
+    WebMock.disable_net_connect!
+  end
+
+  describe 'list_repositories' do
+    it 'returns repos' do
+      # TODO: if we add the Authorization header, the test fails, so
+      # it may mean that the api http_client does not send the header.
+      stub_request(:get, 'http://localhost/sample/api')
+        .to_return(body: json_response(repo_list), headers: { 'Content-Type' => 'application/json' })
+
+      expect(api_client.list_repositories).to eq(repo_list)
+    end
+
+    # TODO: add other tests, especially ones which return !200
+  end
+
+  after(:each) do
+    WebMock.allow_net_connect!
+  end
+end

--- a/spec/unit/libraries/api_spec.rb
+++ b/spec/unit/libraries/api_spec.rb
@@ -27,8 +27,6 @@ describe 'Nexus3::Api' do
 
   describe 'list_repositories' do
     it 'returns repos' do
-      # TODO: if we add the Authorization header, the test fails, so
-      # it may mean that the api http_client does not send the header.
       stub_request(:get, 'http://localhost/sample/api')
         .with(basic_auth: ['admin', 'admin123'])
         .to_return(body: json_response(repo_list), headers: { 'Content-Type' => 'application/json' })

--- a/spec/unit/libraries/api_spec.rb
+++ b/spec/unit/libraries/api_spec.rb
@@ -29,7 +29,7 @@ describe 'Nexus3::Api' do
   describe 'list_repositories' do
     it 'returns repos' do
       stub_request(:get, 'http://localhost/sample/api')
-        .with(basic_auth: %w[admin admin123])
+        .with(basic_auth: %w(admin admin123))
         .to_return(body: json_response(repo_list), headers: { 'Content-Type' => 'application/json' })
 
       expect(api_client.list_repositories).to eq(repo_list)

--- a/spec/unit/libraries/api_spec.rb
+++ b/spec/unit/libraries/api_spec.rb
@@ -1,4 +1,5 @@
 # coding: utf-8
+
 require_relative '../../spec_helper'
 
 describe 'Nexus3::Api' do
@@ -11,13 +12,13 @@ describe 'Nexus3::Api' do
       {
         'name' => 'foo',
         'content' => 'repository.createMavenHosted(\'foo\')',
-        'type' => 'groovy',
+        'type' => 'groovy'
       },
       {
         'name' => 'anonymous',
         'content' => 'security.setAnonymousAccess(Boolean.valueOf(args))',
-        'type' => 'groovy',
-      },
+        'type' => 'groovy'
+      }
     ]
   end
 
@@ -28,7 +29,7 @@ describe 'Nexus3::Api' do
   describe 'list_repositories' do
     it 'returns repos' do
       stub_request(:get, 'http://localhost/sample/api')
-        .with(basic_auth: ['admin', 'admin123'])
+        .with(basic_auth: %w[admin admin123])
         .to_return(body: json_response(repo_list), headers: { 'Content-Type' => 'application/json' })
 
       expect(api_client.list_repositories).to eq(repo_list)


### PR DESCRIPTION
This will be later used first as a LWRP to provide an easy way to list, create
or update repositories.