### PR TITLE
Remove test of init.d link creation

### DIFF
--- a/spec/unit/default_spec.rb
+++ b/spec/unit/default_spec.rb
@@ -54,10 +54,6 @@ describe 'nexus3::default' do
       expect(chef_run).to create_link('/opt/nexus3')
     end
 
-    it 'does not create init.d link' do
-      expect(chef_run).to create_link('/etc/init.d/nexus')
-    end
-
     it 'creates service' do
       expect(chef_run).to enable_service('nexus')
     end


### PR DESCRIPTION
On CentOS 7, systemd does not create symlinks in init.d.