### PR TITLE
Add support for SSL when testing for redirects

### DIFF
--- a/providers/default.rb
+++ b/providers/default.rb
@@ -10,7 +10,8 @@ end
 # http://download.sonatype.com/nexus/3/nexus-3.0.1-01-unix.tar.gz
 def download_url(url)
   uri = URI(url)
-  response = Net::HTTP.start(uri.host) { |http| http.get uri.request_uri }
+  options = { use_ssl: uri.scheme == 'https' }
+  response = Net::HTTP.start(uri.host, uri.port, options) { |http| http.get uri.request_uri }
 
   unless response.is_a?(Net::HTTPRedirection)
     return response['location'].nil? ? url : response['location']


### PR DESCRIPTION
I ran into issues with using this cookbook in an air-gapped environment
where the Nexus binaries were hosted over SSL on a web server with a
certificate issued by an internal Certificate Authority.

This patch ensures that the pre-download check, which is intended to
follow redirect responses, provides the `net/http` library with the
proper port number to issue the request against and enables SSL if the
download URL uses the `https` scheme.