### PR TITLE
Increase number of open files (systemd systems)

### DIFF
--- a/templates/default/systemd_unit.erb
+++ b/templates/default/systemd_unit.erb
@@ -4,6 +4,7 @@ After=network.target
 
 [Service]
 Type=forking
+LimitNOFILE=65536
 ExecStart=<%= @install_dir %>/bin/nexus start
 ExecStop=<%= @install_dir %>/bin/nexus stop
 User=<%= @nexus3_user %>


### PR DESCRIPTION
This is a recommended setting starting with Nexus 3.5.0, but will likely not
be harmful in previous supported versions.

Documented in
https://help.sonatype.com/display/NXRM3/System+Requirements#filehandles

Should fix #27