### PR TITLE
Set higher nofile limit for nexus service

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -25,3 +25,5 @@ default['nexus3']['vmoptions_variables'] = {
   Xms: '1200M',
   Xmx: '1200M'
 }
+
+default['nexus3']['nofile_limit'] = 65_536

--- a/resources/service_systemd.rb
+++ b/resources/service_systemd.rb
@@ -8,6 +8,7 @@ property :instance_name, String, name_property: true
 property :install_dir, String
 property :nexus3_user, String
 property :nexus3_group, String
+property :nofile_limit, Integer, default: lazy { node['nexus3']['nofile_limit'] }
 
 action :start do
   create_init
@@ -56,7 +57,8 @@ action_class do
       variables(
         instance_name: new_resource.instance_name,
         install_dir: new_resource.install_dir,
-        nexus3_user: new_resource.nexus3_user
+        nexus3_user: new_resource.nexus3_user,
+        nofile_limit: new_resource.nofile_limit
       )
       cookbook 'nexus3'
       notifies :run, 'execute[Load systemd unit file]', :immediately

--- a/templates/default/systemd_unit.erb
+++ b/templates/default/systemd_unit.erb
@@ -4,7 +4,7 @@ After=network.target
 
 [Service]
 Type=forking
-LimitNOFILE=65536
+LimitNOFILE=<%= @nofile_limit %>
 ExecStart=<%= @install_dir %>/bin/nexus start
 ExecStop=<%= @install_dir %>/bin/nexus stop
 User=<%= @nexus3_user %>


### PR DESCRIPTION
This change suppresses a warning that is showed when logged in as an administrator and follows guidance described here:
https://help.sonatype.com/display/NXRM3/System+Requirements#SystemRequirements-AdequateFileHandleLimits