### PR TITLE
Update path to include script for working with the apis.

### DIFF
--- a/libraries/api.rb
+++ b/libraries/api.rb
@@ -38,7 +38,7 @@ module Nexus3
 
     # Runs a specific script with parameters
     def run_script(scriptname, params)
-      body = request(:post, "#{scriptname}/run", 'text/plain', params)
+      body = request(:post, "script/#{scriptname}/run", 'text/plain', params)
       JSON.parse(body)['result']
     end
   end

--- a/resources/api.rb
+++ b/resources/api.rb
@@ -15,7 +15,7 @@ load_current_value do |desired|
   password desired.password
 
   begin
-    response = JSON.parse(apiclient.request(:get, desired.script_name))
+    response = JSON.parse(apiclient.request(:get, "script/#{desired.script_name}"))
     content response['content'] if response.is_a?(Hash) && response.key?('content')
   rescue LoadError, ::Nexus3::ApiError => e
     ::Chef::Log.warn "A '#{e.class}' occured: #{e.message}"
@@ -27,7 +27,7 @@ action :create do
   chef_gem 'httpclient'
 
   converge_if_changed do
-    apiclient.request(:delete, new_resource.script_name) unless current_resource.nil?
+    apiclient.request(:delete, "script/#{new_resource.script_name}") unless current_resource.nil?
     apiclient.request(:post, '', 'application/json', name: new_resource.script_name, type: 'groovy',
                                                      content: new_resource.content)
   end
@@ -46,7 +46,7 @@ action :delete do
 
   unless current_resource.nil?
     converge_by "deleting script #{new_resource.script_name}" do
-      apiclient.request(:delete, new_resource.script_name)
+      apiclient.request(:delete, "script/#{new_resource.script_name}")
     end
   end
 end


### PR DESCRIPTION
When working with the `nexus3_api` resource, I'd get a 404 error when trying to delete the script.

After some investigation, I found that `/script` was missing.

Compare:

* `curl -u admin:admin123 -X "DELETE" http://127.0.0.1:8081/service/siesta/rest/v1/my-script`
* `curl -u admin:admin123 -X "DELETE" https://127.0.0.1:8081/service/siesta/rest/v1/script/my-script`
