### PR TITLE
Use role strings passed to add roles directly to user

### DIFF
--- a/files/default/upsert_user.groovy
+++ b/files/default/upsert_user.groovy
@@ -1,5 +1,4 @@
 import org.sonatype.nexus.security.role.NoSuchRoleException;
-import org.sonatype.nexus.security.role.RoleIdentifier;
 import org.sonatype.nexus.security.user.User;
 import org.sonatype.nexus.security.user.UserManager;
 import org.sonatype.nexus.security.user.UserNotFoundException;
@@ -9,18 +8,6 @@ import groovy.json.JsonSlurper;
 
 def params = new JsonSlurper().parseText(args)
 
-authManager = security.getSecuritySystem().getAuthorizationManager(UserManager.DEFAULT_SOURCE);
-// Create a list of available from the list of passed roles. May end up empty if no role exists.
-Set<RoleIdentifier> roleList = new HashSet<RoleIdentifier>();
-params.roles.each { role ->
-    try {
-        def newRole = authManager.getRole(role);
-        roleList.add(newRole);
-    } catch (NoSuchRoleException e) {
-        log.warn("No such role: ${role}, trying to set for ${params.username} from Chef");
-    }
-}
-
 try {
     // Update
     User user = security.securitySystem.getUser(params.username, UserManager.DEFAULT_SOURCE);
@@ -28,10 +15,12 @@ try {
     user.setFirstName(params.first_name);
     user.setLastName(params.last_name);
     user.setEmailAddress(params.email);
-    user.setRoles(roleList);
 
     security.securitySystem.updateUser(user);
     security.securitySystem.changePassword(params.username, params.password);
+
+    security.setUserRoles(user.getUserId(), params.roles);
+
     log.info("Updated information for ${params.username} from Chef");
 } catch (UserNotFoundException e) {
     // Create


### PR DESCRIPTION
The current code mistakenly assumes getRole on the authManager returns
RoleIdentifiers, when it returns Roles. In any case, the current code
is inconsistent with the user creation code, which uses the strings
directly on the addUser "security" helper object.