### PR TITLE
Introduce a new nexus3_group resource to create repository groups

### DIFF
--- a/.kitchen.appveyor.yml
+++ b/.kitchen.appveyor.yml
@@ -22,6 +22,7 @@ suites:
     - nexus3_test::delete_script
     - nexus3_test::run_script
     - nexus3_test::repositories
+    - nexus3_test::groups
   attributes:
     nexus3_test:
       connection_retries: 10

--- a/.kitchen.docker.yml
+++ b/.kitchen.docker.yml
@@ -80,6 +80,7 @@ suites:
     - nexus3_test::run_script
     - nexus3_test::user
     - nexus3_test::repositories
+    - nexus3_test::groups
     - nexus3_test::roles
     - nexus3_test::tasks
   attributes:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -14,3 +14,6 @@ AbcSize:
 
 BlockLength:
   Max: 130
+
+Style/FormatString:
+  Exclude: ['spec/**/*', 'test/**/*']

--- a/README.md
+++ b/README.md
@@ -22,6 +22,9 @@ resource to configure Nexus 3 Repository Manager via its REST API.
 Use the [nexus3_repo](https://github.com/criteo-cookbooks/nexus3#nexus3_repo)
 resource to configure Nexus 3 repositories.
 
+Use the [nexus3_group](https://github.com/criteo-cookbooks/nexus3#nexus3_group)
+resource to configure Nexus 3 repository groups.
+
 Use the [nexus3_user](https://github.com/criteo-cookbooks/nexus3#nexus3_user)
 resource to configure Nexus 3 users.
 
@@ -261,6 +264,25 @@ Configures scheduled tasks via API.
 - `api_endpoint` - Nexus 3 API endpoint (default: node['nexus3']['api']['endpoint']).
 - `api_username` - Nexus 3 API user name (default: node['nexus3']['api']['username']).
 - `api_password` - Nexus 3 API password (default: node['nexus3']['api']['password']).
+
+## nexus3_group
+
+Configures Nexus 3 repository groups via API. This works wrapping the nexus3_repo
+resource with names of member repositories added as an attribute.
+
+### Actions
+- `:create` - Creates or updates a group, passing a configuration via `attributes`.
+- `:delete` - Deletes a group.
+
+### Properties
+- `group_name` - Name of repository group to act on, defaults to resource property
+  name.
+- `group_type` - Type (or recipe in Nexus 3 words) of repository group to create,
+  among `maven2-group`, 'npm-group`, ... (default: 'maven2-group')
+- `attributes` - Hash of attributes passed to the `:create` action, used to
+  specify repository attributes for creation or update.
+- `online` - Whether to put the repository online or not (default: true).
+- `repositories` - Array of repository names that compose the group.
 
 ## nexus3_user
 

--- a/resources/group.rb
+++ b/resources/group.rb
@@ -1,0 +1,33 @@
+property :group_name, String, name_property: true
+property :group_type, String, regex: /-group$/, default: 'maven2-group'
+property :repositories, Array, default: lazy { [] }
+property :attributes, Hash, default: lazy { ::Mash.new } # Not mandatory but strongly recommended in the generic case.
+property :online, [true, false], default: true
+property :api_endpoint, String, identity: true, default: lazy { node['nexus3']['api']['endpoint'] }
+property :api_username, String, identity: true, default: lazy { node['nexus3']['api']['username'] }
+property :api_password, String, identity: true, sensitive: true,
+                                default: lazy { node['nexus3']['api']['password'] }
+
+action :create do
+  nexus3_repo new_resource.group_name do
+    action :create
+
+    repo_type new_resource.group_type
+    online new_resource.online
+    attributes new_resource.attributes.merge(group: { memberNames: new_resource.repositories })
+
+    api_endpoint new_resource.api_endpoint
+    api_username new_resource.api_username
+    api_password new_resource.api_password
+  end
+end
+
+action :delete do
+  nexus3_repo new_resource.group_name do
+    action :delete
+
+    api_endpoint new_resource.api_endpoint
+    api_username new_resource.api_username
+    api_password new_resource.api_password
+  end
+end

--- a/spec/unit/resources/group_spec.rb
+++ b/spec/unit/resources/group_spec.rb
@@ -1,0 +1,20 @@
+require 'spec_helper'
+
+describe 'nexus3_test::groups' do
+  context 'linux' do
+    let(:chef_run) do
+      ::ChefSpec::SoloRunner.new(platform: 'centos', version: CENTOS_VERSION, step_into: 'nexus3_group')
+                            .converge(described_recipe)
+    end
+
+    it 'creates a group' do
+      expect(chef_run).to create_nexus3_repo('foo-group')
+      expect(chef_run).to create_nexus3_group('foo-group')
+    end
+
+    it 'deletes a group' do
+      expect(chef_run).to delete_nexus3_repo('bar-group')
+      expect(chef_run).to delete_nexus3_group('bar-group')
+    end
+  end
+end

--- a/test/fixtures/cookbooks/nexus3_test/recipes/groups.rb
+++ b/test/fixtures/cookbooks/nexus3_test/recipes/groups.rb
@@ -1,0 +1,56 @@
+repo_conf = Mash.new(
+  storage: {
+    blobStoreName: 'default',
+    writePolicy: 'ALLOW_ONCE'
+  }
+)
+
+group_conf = Mash.new(
+  storage: {
+    blobStoreName: 'default',
+    strictContentTypeValidation: true
+  }
+)
+
+nexus3_repo 'test1' do
+  repo_type 'pypi-hosted'
+  attributes repo_conf
+end
+nexus3_repo 'test2' do
+  repo_type 'pypi-hosted'
+  attributes repo_conf
+end
+
+nexus3_group 'foo-group' do
+  attributes group_conf
+  group_type 'pypi-group'
+  repositories %w(test1 test2)
+end
+
+nexus3_group 'foo-group again' do
+  group_name 'foo-group'
+  group_type 'pypi-group'
+  attributes group_conf
+  repositories %w(test1 test2)
+  notifies :run, 'ruby_block[fail if foo-group is created again]', :immediately
+end
+
+ruby_block 'fail if foo-group is created again' do
+  action :nothing
+  block { raise 'nexus3_group is not idempotent!' }
+end
+
+nexus3_group 'bar-group' do
+  action :delete
+end
+
+nexus3_group 'bar-group again' do
+  group_name 'bar-group'
+  action :delete
+  notifies :run, 'ruby_block[fail if bar-group is deleted again]', :immediately
+end
+
+ruby_block 'fail if bar-group is deleted again' do
+  action :nothing
+  block { raise 'nexus3_group is not idempotent!' }
+end

--- a/test/integration/default/serverspec/groups_spec.rb
+++ b/test/integration/default/serverspec/groups_spec.rb
@@ -1,0 +1,30 @@
+require 'serverspec_helper'
+
+describe 'nexus::groups' do
+  if os[:family] == 'windows'
+    auth_info = "$base64AuthInfo = [Convert]::ToBase64String([Text.Encoding]::ASCII.GetBytes((\"{0}:{1}\" \
+-f 'admin','admin123')));"
+    base_uri = '-URI http://localhost:8081/service/rest/v1/script'
+
+    run_get_group = "#{auth_info} Invoke-RestMethod -Headers @{Authorization=(\"Basic {0}\" -f $base64AuthInfo)} \
+#{base_uri}/get_repo/run -Method POST -ContentType 'text/plain' -Body '%{group}'"
+
+    describe command("powershell -command { #{run_get_group} }" % { group: 'foo-group' }) do
+      its(:stdout) { should contain('result').before('foo-group') }
+    end
+
+    describe command("powershell -command { #{run_get_group_doesnotexist} }" % { group: nil }) do
+      its(:stdout) { should contain('get_repo').before('null') }
+    end
+  else # Linux
+    describe command('curl -uadmin:admin123 http://localhost:8081/service/rest/v1/script/get_repo/run ' \
+                     '-X POST -H "Content-Type: text/plain" -d foo-group') do
+      its(:stdout) { should contain('result').before('repositoryName=').before('foo-group') }
+    end
+
+    describe command('curl -uadmin:admin123 http://localhost:8081/service/rest/v1/script/get_repo/run ' \
+                     '-X POST -H "Content-Type: text/plain" -d doesnotexist') do
+      its(:stdout) { should contain('result').before('null') }
+    end
+  end
+end


### PR DESCRIPTION
This is just a wrapper on top of the `nexus3_repo` resource.
This allows the following syntax:

```ruby
nexus3_repo_group 'create my group' do
  group_name 'my_group'
  repositories %w(repo1 repo2)
end
```

Fix #14