### PR TITLE
Use class Nexus3::Api as resource property

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,12 +102,8 @@ include_recipe 'nexus3'
 
 ## Properties common to all resources using the Nexus3 API
 
-- `api_endpoint` - URL to reach the Nexus3 API. Default
-  `node['nexus3']['api']['endpoint']`
-- `api_username` - username to authenticate to the Nexus3 API. Default
-  `node['nexus3']['api'][username]`
-- `api_password` - password to authenticate to the Nexus3 API. Default
-  `node['nexus3']['api']['password']`
+`api_client` - A ::Nexus3::Api instance. Default is configured using
+following `nexus3.api` attributes: `endpoint`, `username` & `password`
 
 ## nexus3
 
@@ -201,9 +197,6 @@ used within other resources.
   documentation](https://books.sonatype.com/nexus-book/3.1/reference/scripting.html) for
   more information, or see the example scripts in the `repo` resource.
 - `args` - Hash, String or NilClass arguments passed when `:run` is called.
-- `endpoint` - REST API endpoint. Default `node['nexus3']['api']['endpoint']`.
-- `username` - Username to run the script as. Default `admin`.
-- `password` - Password of username.  Default `admin123`.
 
 ### Examples
 
@@ -242,9 +235,6 @@ the help of `libraries/scripts_helper.rb`.
 - `attributes` - Hash of attributes passed to the `:create` action, used to
   specify repository attributes for creation or update.
 - `online` - Whether to put the repository online or not (default: true).
-- `api_endpoint` - Nexus 3 API endpoint (default: node['nexus3']['api']['endpoint']).
-- `api_username` - Nexus 3 API user name (default: node['nexus3']['api']['username']).
-- `api_password` - Nexus 3 API password (default: node['nexus3']['api']['password']).
 
 ## nexus3_task
 
@@ -261,9 +251,6 @@ Configures scheduled tasks via API.
 - `task_source` - Source code of the script to run, for now it defaults to
   running Groovy scripts (typeID: script).
 - `task_crontab` - Actual schedule in the form of a crontab string.
-- `api_endpoint` - Nexus 3 API endpoint (default: node['nexus3']['api']['endpoint']).
-- `api_username` - Nexus 3 API user name (default: node['nexus3']['api']['username']).
-- `api_password` - Nexus 3 API password (default: node['nexus3']['api']['password']).
 
 ## nexus3_group
 

--- a/attributes/api.rb
+++ b/attributes/api.rb
@@ -1,7 +1,6 @@
 default['nexus3']['api']['script_cookbook'] = 'nexus3'
 default['nexus3']['api']['type'] = 'groovy'
-default['nexus3']['api']['host'] = 'http://localhost:8081'
-default['nexus3']['api']['endpoint'] = "#{node['nexus3']['api']['host']}/service/rest/v1/script/"
+default['nexus3']['api']['endpoint'] = 'http://localhost:8081/service/rest/v1/script/'
 default['nexus3']['api']['username'] = 'admin'
 default['nexus3']['api']['password'] = 'admin123'
 default['nexus3']['api']['ignore_failure'] = true

--- a/libraries/api.rb
+++ b/libraries/api.rb
@@ -4,10 +4,17 @@ module Nexus3
 
   # Interact with the Nexus3 API
   class Api
+    def self.default(node)
+      new(node['nexus3']['api']['endpoint'],
+          node['nexus3']['api']['username'],
+          node['nexus3']['api']['password']).freeze
+    end
+
     def initialize(base_url, user, password)
       require 'httpclient'
       require 'json'
 
+      @endpoint = base_url
       @http_client = ::HTTPClient.new(base_url: base_url).tap do |client|
         # Authentication
         client.set_auth(base_url, user, password)
@@ -17,7 +24,7 @@ module Nexus3
       end
     end
 
-    attr_reader :http_client
+    attr_reader :http_client, :endpoint
 
     def request(method, path, ct = 'application/json', data = nil)
       data = case data

--- a/resources/group.rb
+++ b/resources/group.rb
@@ -3,10 +3,7 @@ property :group_type, String, regex: /-group$/, default: 'maven2-group'
 property :repositories, Array, default: lazy { [] }
 property :attributes, Hash, default: lazy { ::Mash.new } # Not mandatory but strongly recommended in the generic case.
 property :online, [true, false], default: true
-property :api_endpoint, String, identity: true, default: lazy { node['nexus3']['api']['endpoint'] }
-property :api_username, String, identity: true, default: lazy { node['nexus3']['api']['username'] }
-property :api_password, String, identity: true, sensitive: true,
-                                default: lazy { node['nexus3']['api']['password'] }
+property :api_client, ::Nexus3::Api, identity: true, default: ::Nexus3::Api.default(node)
 
 action :create do
   nexus3_repo new_resource.group_name do
@@ -16,9 +13,7 @@ action :create do
     online new_resource.online
     attributes new_resource.attributes.merge(group: { memberNames: new_resource.repositories })
 
-    api_endpoint new_resource.api_endpoint
-    api_username new_resource.api_username
-    api_password new_resource.api_password
+    api_client new_resource.api_client
   end
 end
 
@@ -26,8 +21,6 @@ action :delete do
   nexus3_repo new_resource.group_name do
     action :delete
 
-    api_endpoint new_resource.api_endpoint
-    api_username new_resource.api_username
-    api_password new_resource.api_password
+    api_client new_resource.api_client
   end
 end

--- a/test/fixtures/cookbooks/nexus3_test/recipes/delete_script.rb
+++ b/test/fixtures/cookbooks/nexus3_test/recipes/delete_script.rb
@@ -1,8 +1,6 @@
 # creates script, then deletes it
 nexus3_api 'bar' do
   content "repository.createMavenHosted('bar')"
-  username 'admin'
-  password 'admin123'
 
   action :create
   retries 10
@@ -11,8 +9,6 @@ end
 
 nexus3_api 'bar' do
   content ''
-  username 'admin'
-  password 'admin123'
 
   action :delete
   retries 10
@@ -22,8 +18,6 @@ end
 nexus3_api 'bar again' do
   script_name 'bar'
   content ''
-  username 'admin'
-  password 'admin123'
 
   action :delete
   notifies :run, 'ruby_block[fail if bar is deleted again]', :immediately

--- a/test/fixtures/cookbooks/nexus3_test/recipes/run_script.rb
+++ b/test/fixtures/cookbooks/nexus3_test/recipes/run_script.rb
@@ -1,8 +1,6 @@
 # adds or updates 'anonymous' script on repository manager and executes it with an argument
 nexus3_api 'anonymous' do
   content 'repository.repositoryManager.browse()'
-  username 'admin'
-  password 'admin123'
 
   action %i(create run)
   retries 10


### PR DESCRIPTION
Instead of always passing the triplet endpoint/username/password it is
simpler to pass an instance of ::Nexus3::Api class.
Default value is configured based on nexus3.api attributes.