### PR TITLE
Capture Errno::EHOSTUNREACH exception:

### DIFF
--- a/libraries/nexus_helper.rb
+++ b/libraries/nexus_helper.rb
@@ -25,6 +25,7 @@ EOH
                Errno::ECONNRESET,
                Errno::ENETUNREACH,
                Errno::EADDRNOTAVAIL,
+               Errno::EHOSTUNREACH,
                OpenURI::HTTPError => e
           # Getting 403 is ok since it means we reached the endpoint and
           # it's asking us for authentication.


### PR DESCRIPTION
On first converge you could hit Errno::EHOSTUNREACH, which was raising an exception rather
than retrying.

```
             System Info:
             ------------
             chef_version=12.21.10
             platform=centos
             platform_version=7.5.1804
             ruby=ruby 2.3.4p301 (2017-03-30 revision 58214) [x86_64-linux]
             program_name=chef-client worker: ppid=370;start=13:59:56;
             executable=/opt/chef/bin/chef-client


           ================================================================================
           Error executing action `install` on resource 'nexus3[default]'
           ================================================================================

           Errno::EHOSTUNREACH
           -------------------
           ruby_block[block until operational] (/tmp/kitchen/cache/cookbooks/nexus3/resources/default.rb line 102) had an error: Errno::EHOSTUNREACH: Failed to open TCP connection to localhost:8081 (No route to host - connect(2) for "localhost" port 8081)

           Cookbook Trace:
           ---------------
           /tmp/kitchen/cache/cookbooks/nexus3/libraries/nexus_helper.rb:22:in `block in wait_until_ready!'
           /tmp/kitchen/cache/cookbooks/nexus3/libraries/nexus_helper.rb:20:in `wait_until_ready!'
           /tmp/kitchen/cache/cookbooks/nexus3/resources/default.rb:105:in `block (3 levels) in class_from_file'

           Resource Declaration:
           ---------------------
           # In /tmp/kitchen/cache/cookbooks/xxx_nexus/recipes/default.rb

             1: nexus3 'default' do
             2:   url node['xxx_nexus']['url']
```

It's preventing us to use the cookbook without doing a double converge