### PR TITLE
Install httpclient at compile time in the api resource

### DIFF
--- a/resources/api.rb
+++ b/resources/api.rb
@@ -14,7 +14,9 @@ load_current_value do |desired|
 end
 
 action :create do
-  chef_gem 'httpclient'
+  chef_gem 'httpclient' do
+    compile_time true
+  end
 
   converge_if_changed do
     new_resource.api_client.request(:delete, new_resource.script_name) unless current_resource.nil?
@@ -24,7 +26,9 @@ action :create do
 end
 
 action :run do
-  chef_gem 'httpclient'
+  chef_gem 'httpclient' do
+    compile_time true
+  end
 
   converge_by "running script #{new_resource.script_name}" do
     new_resource.api_client.run_script(new_resource.script_name, new_resource.args)
@@ -32,7 +36,9 @@ action :run do
 end
 
 action :delete do
-  chef_gem 'httpclient'
+  chef_gem 'httpclient' do
+    compile_time true
+  end
 
   unless current_resource.nil?
     converge_by "deleting script #{new_resource.script_name}" do


### PR DESCRIPTION
## Scenario:

Using `nexus3_api3` immediately after `nexus3` installation results in error that `httpclient` gem missing.

- Chef 14
- Redhat 7

## Error
```
* nexus3_api[admin_change_password] action create[2018-08-10T17:00:32+10:00] WARN: A 'LoadError' occured: cannot load such file -- httpclient
       [2018-08-10T17:00:32+10:00] WARN: A 'LoadError' occured: cannot load such file -- httpclient
...
[2018-08-10T17:00:32+10:00] FATAL: Stacktrace dumped to /tmp/kitchen/cache/chef-stacktrace.out
[2018-08-10T17:00:32+10:00] FATAL: Please provide the contents of the stacktrace.out file if you file a bug report
[2018-08-10T17:00:32+10:00] FATAL: LoadError: cannot load such file -- httpclient
```
