### PR TITLE
Extend nexus.properties with application-port-ssl

### DIFF
--- a/templates/default/nexus.properties.erb
+++ b/templates/default/nexus.properties.erb
@@ -1,5 +1,6 @@
 # Jetty section
-application-port=<%=@port%>
+<% if @port %>application-port=<%=@port%><% end %>
+<% if @port_ssl %>application-port-ssl=<%=@port_ssl%><% end %>
 application-host=<%=@host%>
 nexus-args=<%=@args%>
 nexus-context-path=<%=@context_path%>


### PR DESCRIPTION
keystore has to be created manually, but at least we can set `application-port-ssl` for `nexus.properties` by setting
```
default['nexus3']['properties_variables'] = {
  host: '0.0.0.0',
  port: '80',
  port_ssl: 443,
  args: '${jetty.etc}/jetty.xml,${jetty.etc}/jetty-http.xml,${jetty.etc}/jetty-https.xml,${jetty.etc}/jetty-requestlog.xml',
  context_path: '/'
}
```