### PR TITLE
Bump nexus3 version to 3.15.2

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -6,7 +6,7 @@ else
   default['nexus3']['group'] = 'nexus'
 end
 # Download URL is defined in the resource but you can override it with the default['nexus3']['url'] attribute
-default['nexus3']['version'] = '3.8.0-02'
+default['nexus3']['version'] = '3.15.2-01'
 default['nexus3']['url'] = "https://download.sonatype.com/nexus/3/nexus-#{node['nexus3']['version']}-unix.tar.gz"
 default['nexus3']['checksum'] = nil # optional
 default['nexus3']['home'] = "#{node['nexus3']['path']}/nexus3"

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,7 +2,7 @@ require 'chefspec'
 require 'chefspec/berkshelf'
 require 'webmock/rspec'
 
-VER = '3.8.0-02'.freeze
+VER = '3.15.2-01'.freeze
 CACHE = Chef::Config[:file_cache_path]
 CENTOS_VERSION = '7.4.1708'.freeze
 


### PR DESCRIPTION
3.8.0 is very old.
Let's move to 3.15.2 which brings lots of new features and fixes.