### PR TITLE
Allow other cookbooks to load their groovy scripts existing helpers

### DIFF
--- a/libraries/scripts_helper.rb
+++ b/libraries/scripts_helper.rb
@@ -1,13 +1,13 @@
 module Nexus3
   # Load Groovy scripts via the Nexus3 API.
   class Scripts
-    def self.groovy_script_location(script_name, node)
-      cookbook = node.run_context.cookbook_collection['nexus3']
+    def self.groovy_script_location(script_name, node, cookbook_name)
+      cookbook = node.run_context.cookbook_collection[cookbook_name]
       cookbook.preferred_filename_on_disk_location(node, :files, "#{script_name}.groovy")
     end
 
-    def self.groovy_content(script_name, node)
-      ::File.read groovy_script_location(script_name, node)
+    def self.groovy_content(script_name, node, cookbook_name = 'nexus3')
+      ::File.read groovy_script_location(script_name, node, cookbook_name)
     end
   end
 end


### PR DESCRIPTION
If we want to use ::Nexus3.groovy_content helper to upload a custom
groovy scripts, we should be able to specify in which cookbook the
script file resides, else we would need to merge all users scripts
in this cookbook.