### PR TITLE
Replace Oracle Java by OpenJDK

### DIFF
--- a/.kitchen.docker.yml
+++ b/.kitchen.docker.yml
@@ -16,12 +16,6 @@ verifier:
   sudo: false
 
 platforms:
-- name: centos-6
-  driver:
-    image: centos:6
-    intermediate_instructions:
-      - RUN yum -y install tar which initscripts
-
 - name: centos-7
   driver:
     image: centos:7
@@ -30,38 +24,14 @@ platforms:
       - RUN yum -y install net-tools lsof
     pid_one_command: /usr/lib/systemd/systemd
 
-- name: debian-8
+- name: fedora-29
   driver:
-    image: debian:8
-    pid_one_command: /bin/systemd
-    intermediate_instructions:
-      - RUN /usr/bin/apt-get update
-      - RUN /usr/bin/apt-get install apt-transport-https net-tools curl -y
-
-- name: fedora-latest
-  driver:
-    image: fedora:latest
+    image: fedora:29
     intermediate_instructions:
     - RUN yum clean all
     pid_one_command: /usr/lib/systemd/systemd
     intermediate_instructions:
       - RUN yum -y install tar yum
-
-- name: ubuntu-12.04
-  driver:
-    image: ubuntu-upstart:12.04
-    pid_one_command: /sbin/init
-    intermediate_instructions:
-      - RUN /usr/bin/apt-get update
-      - RUN /usr/bin/apt-get install apt-transport-https net-tools curl -y
-
-- name: ubuntu-14.04
-  driver:
-    image: ubuntu-upstart:14.04
-    pid_one_command: /sbin/init
-    intermediate_instructions:
-      - RUN /usr/bin/apt-get update
-      - RUN /usr/bin/apt-get install apt-transport-https net-tools curl -y
 
 - name: ubuntu-16.04
   driver:

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,13 +18,9 @@ sudo: required
 services: docker
 env:
   matrix:
-  - INSTANCE=default-centos-6
   - INSTANCE=default-centos-7
-  - INSTANCE=default-ubuntu-1204
-  - INSTANCE=default-ubuntu-1404
   - INSTANCE=default-ubuntu-1604
-  - INSTANCE=default-debian-8
-  - INSTANCE=default-fedora-latest
+  - INSTANCE=default-fedora-29
 before_script:
 - sudo iptables -L DOCKER || ( echo "DOCKER iptables chain missing" ; sudo iptables
   -N DOCKER )

--- a/test/fixtures/cookbooks/nexus3_test/attributes/default.rb
+++ b/test/fixtures/cookbooks/nexus3_test/attributes/default.rb
@@ -1,3 +1,6 @@
 default['nexus3']['api']['username'] = 'admin'
 default['nexus3']['api']['password'] = 'admin123'
 default['nexus3']['api']['endpoint'] = 'http://localhost:8081/service/rest/v1/script/'
+
+default['java']['install_flavor'] = 'openjdk'
+default['java']['jdk_version'] = '8'

--- a/test/fixtures/cookbooks/nexus3_test/metadata.rb
+++ b/test/fixtures/cookbooks/nexus3_test/metadata.rb
@@ -7,4 +7,4 @@ long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 version '0.1.0'
 
 depends 'nexus3'
-depends 'java_se', '~> 8.0'
+depends 'java'

--- a/test/fixtures/cookbooks/nexus3_test/recipes/default.rb
+++ b/test/fixtures/cookbooks/nexus3_test/recipes/default.rb
@@ -1,4 +1,4 @@
-include_recipe 'java_se'
+include_recipe 'java' unless platform_family?('windows')
 
 package 'curl'
 


### PR DESCRIPTION
Every once in a while, the download of Java is broken,
this time it is due to Java requiring to sign-in before
downloading the sdk.


NOTE: This change also reduces the test matrix to be able to
      use openjdk. New versions of debian and ubuntu are not
      added as their image does not contain systemd, this
      require some work to find other images, or build ours.
      To be eventually done in the future.