### PR TITLE
Avoid forcing default version to all users

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -7,7 +7,7 @@ else
 end
 # Download URL is defined in the resource but you can override it with the default['nexus3']['url'] attribute
 default['nexus3']['version'] = '3.20.0-04'
-default['nexus3']['url'] = "https://download.sonatype.com/nexus/3/nexus-#{node['nexus3']['version']}-unix.tar.gz"
+default['nexus3']['url'] = nil # optional
 default['nexus3']['checksum'] = nil # optional
 default['nexus3']['home'] = "#{node['nexus3']['path']}/nexus3"
 default['nexus3']['data'] = "#{node['nexus3']['path']}/sonatype-work/nexus3"

--- a/resources/default.rb
+++ b/resources/default.rb
@@ -3,7 +3,7 @@ property :nexus3_user, [String, NilClass], default: lazy { node['nexus3']['user'
 property :nexus3_group, [String, NilClass], default: lazy { node['nexus3']['group'] }
 property :nexus3_password, String, sensitive: true, default: lazy { node['nexus3']['api']['password'] } # Admin password
 property :version, String, default: lazy { node['nexus3']['version'] }
-property :url, String, default: lazy { node['nexus3']['url'] }
+property :url, [String, NilClass], default: lazy { node['nexus3']['url'] }
 property :checksum, [String, NilClass], default: lazy { node['nexus3']['checksum'] }
 property :nexus3_home, String, default: lazy { node['nexus3']['home'] }
 property :path, String, default: lazy { node['nexus3']['path'] }


### PR DESCRIPTION
By setting nexus3.url in the default attributes, nexus3 resource
download_url will always be set to nexus3.url, so it would not work
on windows, and on top of that, a user cannot force another version
by just updating nexus3.version, he/she also needs to set the
nexus3.url.

This change brings the default behavior, to have nexus3.url nil, so
it is interpolated at runtime, and a use can override the version just
by updating nexus3.version attribute.

Fixes #100