### PR TITLE
Ensure all vmoptions have a new line

### DIFF
--- a/resources/default.rb
+++ b/resources/default.rb
@@ -62,14 +62,14 @@ action :install do
   end
 
   vmoptions = new_resource.vmoptions_variables.map do |k, v|
-    v.nil? ? "-#{k}" : "-#{k}=#{v}"
+    v.nil? ? "-#{k}\n" : "-#{k}=#{v}\n"
   end
 
   file ::File.join(install_dir, 'bin', 'nexus.vmoptions') do
     owner new_resource.nexus3_user
     group new_resource.nexus3_group
     mode '0644'
-    content vmoptions.join("\n")
+    content vmoptions.join
     notifies :restart, "nexus3_service[#{new_resource.service_name}]", :delayed
     notifies :run, 'ruby_block[block until operational]', :delayed
   end


### PR DESCRIPTION
The init script reads each line of nexus.vmoptions and appends it
to the start command, but for it to read the line, it must end with
a new line. If there is no new line, the option is ignored, which
if using only join("\n") is the case of the last option.

This commit ensures all options have a new line, so none are ignored.