### PR TITLE
Support Multi-policy Cleanup on repo creation

### DIFF
--- a/files/default/upsert_repo.groovy
+++ b/files/default/upsert_repo.groovy
@@ -4,6 +4,18 @@ import org.sonatype.nexus.repository.config.Configuration
 
 def params = new JsonSlurper().parseText(args)
 
+if (params.multi_policy_cleanup_support && params.attributes.containsKey("cleanup")) {
+  // To be compatible with current configs, if we have a String, make it
+  // a List, so we can then convert it to a Set.
+  if (params.attributes["cleanup"]["policyName"] instanceof String) {
+      params.attributes["cleanup"]["policyName"] = [params.attributes["cleanup"]["policyName"]]
+  }
+  // Ensure we convert policyName to a set, as it is now required by
+  // CleanupConfigurationValidator even if we do not use multiple
+  // cleanup policies.
+  params.attributes["cleanup"]["policyName"] = params.attributes["cleanup"]["policyName"].toSet()
+}
+
 def repo = repository.repositoryManager.get(params.name)
 Configuration conf
 if (repo == null) { // create

--- a/resources/repo.rb
+++ b/resources/repo.rb
@@ -30,7 +30,9 @@ action :create do
       args name: new_resource.repo_name,
            type: new_resource.repo_type,
            online: new_resource.online,
-           attributes: new_resource.attributes
+           attributes: new_resource.attributes,
+           multi_policy_cleanup_support: Gem::Version.new(node['nexus3']['version'].split('-').first) >=
+                                         Gem::Version.new('3.19.0')
 
       action %i(create run)
       api_client new_resource.api_client


### PR DESCRIPTION
Starting with 3.19.0, (NEXUS-19525) Multi-policy Cleanup has been added
allowing a repository to have multiple cleanup policies. So the API
has been updated too and now only supports the *Set* Java type as
policyName of the cleanup attribute when creating a repo.

This change ensures backward compatibility:
  * the upsert_repo.groovy takes an extra argument to know if it must
    convert policyName to a set. true if nexus >= 3.19.0
  * users do not have to update their attributes, they can pass a simple
    policyName string (like before), or an array and they will be converted
    to a Set compatible with Multi-policy Cleanup

The following syntaxes are accepted for nexus3_repo attributes:

  { cleanup: { policyName: 'raw_10days_idle' } }
  { cleanup: { policyName: ['raw_10days_idle'] } }
  { cleanup: { policyName: ['raw_10days_idle', 'raw_shortlived'] } }

Of course the array syntax will only work for nexus >= 3.19.0