### PR TITLE
Fix and test multiple Nexus instances on Linux 

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -19,4 +19,5 @@ end
 # Other gems should go after this comment
 gem 'faraday', '<0.16.0' # Newer version is incompatible with this cookbook.
 gem 'kitchen-inspec'
+gem 'rspec-retry'
 gem 'rubocop', '=0.47.1'

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -34,14 +34,8 @@ default['nexus3']['vmoptions_variables']['XX:+UnlockDiagnosticVMOptions'] = nil
 default['nexus3']['vmoptions_variables']['XX:+UnsyncloadClass'] = nil
 default['nexus3']['vmoptions_variables']['XX:+LogVMOutput'] = nil
 default['nexus3']['vmoptions_variables']['XX:MaxDirectMemorySize'] = '39158M'
-default['nexus3']['vmoptions_variables']['Dkaraf.data'] = node['nexus3']['data']
 default['nexus3']['vmoptions_variables']['Dkaraf.etc'] = 'etc/karaf'
 default['nexus3']['vmoptions_variables']['Dkaraf.base'] = '.'
 default['nexus3']['vmoptions_variables']['Dkaraf.home'] = '.'
 default['nexus3']['vmoptions_variables']['Dkaraf.startLocalConsole'] = false
 default['nexus3']['vmoptions_variables']['Djava.net.preferIPv4Stack'] = true
-on_attribute_update('nexus3', 'data') do
-  default['nexus3']['vmoptions_variables']['XX:LogFile'] = ::File.join(node['nexus3']['data'], 'log', 'jvm.log')
-  default['nexus3']['vmoptions_variables']['Dkaraf.data'] = node['nexus3']['data']
-  default['nexus3']['vmoptions_variables']['Djava.io.tmpdir'] = ::File.join(node['nexus3']['data'], 'tmp')
-end

--- a/resources/default.rb
+++ b/resources/default.rb
@@ -61,7 +61,13 @@ action :install do
     notifies :run, 'ruby_block[block until operational]', :delayed
   end
 
-  vmoptions = new_resource.vmoptions_variables.map do |k, v|
+  vars = new_resource.vmoptions_variables.dup
+
+  vars['XX:LogFile'] ||= ::File.join(new_resource.data, 'log', 'jvm.log')
+  vars['Dkaraf.data'] ||= new_resource.data
+  vars['Djava.io.tmpdir'] ||= ::File.join(new_resource.data, 'tmp')
+
+  vmoptions = vars.map do |k, v|
     v.nil? ? "-#{k}\n" : "-#{k}=#{v}\n"
   end
 

--- a/spec/unit/resources/default_spec.rb
+++ b/spec/unit/resources/default_spec.rb
@@ -65,7 +65,7 @@ describe 'nexus3_test::default' do
 
     it 'enables nexus service' do
       expect(chef_run).to enable_nexus3_service('foo')
-      expect(chef_run).to enable_nexus3_service('3.4.0-02')
+      expect(chef_run).to enable_nexus3_service('bar')
     end
 
     it 'blocks until operational does nothing' do

--- a/spec/unit/resources/repo_spec.rb
+++ b/spec/unit/resources/repo_spec.rb
@@ -27,8 +27,8 @@ describe 'nexus3_test::repositories' do
       expect(chef_run).to create_nexus3_api('get_repo foo')
       expect(chef_run).to create_nexus3_api('upsert_repo foo')
       expect(chef_run).to run_nexus3_api('upsert_repo foo').with(
-        repo_name: 'foo',
-        repo_type: 'maven2-hosted'
+        args: hash_including(name: 'foo',
+                             type: 'maven2-hosted')
       )
     end
 
@@ -36,7 +36,9 @@ describe 'nexus3_test::repositories' do
       expect(chef_run).to delete_nexus3_repo('bar')
       expect(chef_run).to create_nexus3_api('get_repo bar')
       expect(chef_run).to create_nexus3_api('delete_repo bar')
-      expect(chef_run).to run_nexus3_api('delete_repo bar').with(repo_name: 'bar')
+      expect(chef_run).to run_nexus3_api('delete_repo bar').with(
+        args: 'bar'
+      )
     end
   end
 end

--- a/test/fixtures/cookbooks/nexus3_test/recipes/default.rb
+++ b/test/fixtures/cookbooks/nexus3_test/recipes/default.rb
@@ -7,23 +7,14 @@ nexus3 'foo'
 
 # Second installation on the same machine with altered settings (not
 # tested on Windows).
-# This shows it can be done. Integration tests show
-# that one must not miss changing any property or files will be
-# overwritten.
 unless platform_family?('windows')
+  package 'iproute' # inspec tests on fedora-29 need this for `ss`
   nexus3 'bar' do
     path '/usr/local/nexusbar'
     data '/usr/local/nexusdata'
     nexus3_user 'nexusbar'
     nexus3_group 'nexusbar'
     nexus3_home '/home/nexusbar'
-    version '3.4.0-02'
-    service_name '3.4.0-02'
-    properties_variables(
-      host: '0.0.0.0',
-      port: '8082',
-      args: '${jetty.etc}/jetty.xml,${jetty.etc}/jetty-http.xml,${jetty.etc}/jetty-requestlog.xml',
-      context_path: '/'
-    )
+    properties_variables(node['nexus3']['properties_variables'].merge(port: '8082'))
   end
 end


### PR DESCRIPTION
There was an example of how to start multiple instances without any tests on the second instance.  However, the second instance didn't in fact start. This PR fixes multiple instance and adds simple tests on the service starting and listening to the socket. A later PR will change a second instance's admin password and add functionality tests on the second instance.