### PR TITLE
Knob to configure outbound proxy

### DIFF
--- a/.kitchen.docker.yml
+++ b/.kitchen.docker.yml
@@ -54,6 +54,7 @@ suites:
     - nexus3_test::roles
     - nexus3_test::tasks
     - nexus3_test::cleanup_policies
+    - nexus3_test::outbound_proxy
   attributes:
     nexus3_test:
       connection_retries: 10

--- a/README.md
+++ b/README.md
@@ -76,6 +76,8 @@ Downloads and installs the latest Nexus 3 Repository Manager OSS.
 - `node['nexus3']['nofile_limit']` - Limit of open files available for the
   Nexus3 service in systemd. Default 65,536 as suggested by the Sonatype
   documentation on newer releases.
+- `node['nexus3']['outbound_proxy']` - Configure outbound HTTP/HTTPS proxy. See example
+  'Configure outbound HTTP/HTTPS proxy for all the attributes.'
 
 ### Examples
 
@@ -105,6 +107,40 @@ include_recipe 'nexus3'
 
 The `vmoptions_variables` attributes are mapped to JVM options `-<key>=<value>` if a value
 is defined. If `<value>` is `nil`, the option becomes `-<key>`.
+
+#### Configure outbound HTTP/HTTPS proxy
+
+```ruby
+node.default['nexus3']['outbound_proxy'] = {
+  'http' => {
+    'host' => 'proxy.example.com',
+    'port' => 80,
+    'auth' => {
+      'username' => 'example',
+      'password' => 'secret',
+      'host' => 'NTLM host',
+      'domain' => 'NTLM domain',
+    },
+  },
+  'https' => {
+    'host' => 'proxy.example.com',
+    'port' => 80,
+    'auth' => {
+      'username' => 'example',
+      'password' => 'secret',
+      'host' => 'NTLM host',
+      'domain' => 'NTLM domain',
+    },
+  },
+  'non_proxy_hosts' => ['rubygems.org', '*.chef.io'],
+}
+```
+
+`http` is mandatory, it is a prerequisite to configure the outbound proxy,
+you cannot just configure `https` for example, it would not be valid.
+
+`auth` can be ommited if you do not want to configure authentication. Only set
+`username` and `password` for basic authentication, else it will be NTLM.
 
 # Resources
 
@@ -149,6 +185,7 @@ directories, as well as different port numbers.
 - `vmoptions_variables` - A Hash of variables that are passed into a template
   file. Note that data directory will be injected into the hash if it is not
   defined. Default `node['nexus3']['vmoptions_variables']`.
+- `outbound_proxy` - Configure outbound HTTP/HTTPS proxy. Default `node['nexus3']['outbound_proxy']`.
 
 ### Examples
 

--- a/files/default/delete_outbound_proxy.groovy
+++ b/files/default/delete_outbound_proxy.groovy
@@ -1,0 +1,2 @@
+core.removeHTTPSProxy()
+core.removeHTTPProxy()

--- a/files/default/get_outbound_proxy.groovy
+++ b/files/default/get_outbound_proxy.groovy
@@ -1,0 +1,47 @@
+import groovy.json.JsonOutput
+import org.sonatype.nexus.httpclient.config.ProxyServerConfiguration
+import org.sonatype.nexus.httpclient.config.UsernameAuthenticationConfiguration
+import org.sonatype.nexus.httpclient.config.NtlmAuthenticationConfiguration
+
+Map configMap(ProxyServerConfiguration psc) {
+    def config = [host: psc.getHost(), port: psc.getPort()]
+    def auth = psc.getAuthentication()
+    if (auth == null) {
+        return config
+    }
+
+    switch (auth.getType()) {
+        case UsernameAuthenticationConfiguration.TYPE:
+            def ua = (UsernameAuthenticationConfiguration)auth
+            config["auth"] = [username: ua.getUsername(), password: ua.getPassword()]
+            break
+        case NtlmAuthenticationConfiguration.TYPE:
+            def na = (NtlmAuthenticationConfiguration)auth
+            config["auth"] = [
+                    username: na.getUsername(),
+                    password: na.getPassword(),
+                    host: na.getHost(),
+                    domain: na.getDomain(),
+            ]
+            break
+    }
+    return config
+}
+
+def existingConfig = [:]
+
+// From the UI you must first configure the HTTP proxy, then the HTTPS
+// proxy. So if the all proxy is null or the http proxy, consider nothing
+// is configured.
+proxy = core.httpClientManager.getConfiguration().getProxy()
+if (proxy == null || proxy.getHttp() == null) {
+    return JsonOutput.toJson(existingConfig) // Always return an empty map
+}
+
+existingConfig['non_proxy_hosts'] = proxy.getNonProxyHosts()
+existingConfig['http'] = configMap(proxy.getHttp())
+if (proxy.getHttps() != null) {
+    existingConfig['https'] = configMap(proxy.getHttps())
+}
+
+return JsonOutput.toJson(existingConfig)

--- a/files/default/upsert_outbound_proxy.groovy
+++ b/files/default/upsert_outbound_proxy.groovy
@@ -1,0 +1,48 @@
+import groovy.json.JsonSlurper
+
+def params = new JsonSlurper().parseText(args)
+if (params.http["auth"]) {
+    if (params.http["auth"]["domain"]) {
+        core.httpProxyWithNTLMAuth(
+                (String)params.http["host"],
+                (int)params.http["port"],
+                (String)params.http["auth"]["username"],
+                (String)params.http["auth"]["password"],
+                (String)params.http["auth"]["host"],
+                (String)params.http["auth"]["domain"])
+    } else {
+        core.httpProxyWithBasicAuth(
+                (String)params.http["host"],
+                (int)params.http["port"],
+                (String)params.http["auth"]["username"],
+                (String)params.http["auth"]["password"])
+    }
+} else {
+    core.httpProxy((String)params.http["host"], (int)params.http["port"])
+}
+
+core.nonProxyHosts(params.non_proxy_hosts as String[])
+
+if (params.https) {
+    if (params.https["auth"]) {
+        if (params.https["auth"]["domain"]) {
+            core.httpsProxyWithNTLMAuth(
+                    (String)params.https["host"],
+                    (int)params.https["port"],
+                    (String)params.https["auth"]["username"],
+                    (String)params.https["auth"]["password"],
+                    (String)params.https["auth"]["host"],
+                    (String)params.https["auth"]["domain"])
+        } else {
+            core.httpsProxyWithBasicAuth(
+                    (String)params.https["host"],
+                    (int)params.https["port"],
+                    (String)params.https["auth"]["username"],
+                    (String)params.https["auth"]["password"])
+        }
+    } else {
+        core.httpsProxy((String)params.https["host"], (int)params.https["port"])
+    }
+} else {
+    core.removeHTTPSProxy() // Ensure it is cleaned, in case it was configured before.
+}

--- a/resources/outbound_proxy.rb
+++ b/resources/outbound_proxy.rb
@@ -1,0 +1,61 @@
+property :config, Hash, default: lazy { ::Mash.new }
+property :api_client, ::Nexus3::Api, identity: true, default: lazy { ::Nexus3::Api.default(node) }
+
+load_current_value do
+  begin
+    cfg = ::JSON.parse(api_client.run_script('get_outbound_proxy', nil))
+    current_value_does_not_exist! if cfg.nil?
+    config cfg
+    ::Chef::Log.debug "Config is: #{config}"
+  # We rescue here because during the first run, the repository will not exist yet, so we let Chef know that
+  # the resource has to be created.
+  rescue LoadError, ::Nexus3::ApiError => e
+    ::Chef::Log.warn "A '#{e.class}' occured: #{e.message}"
+    current_value_does_not_exist!
+  end
+end
+
+action :create do
+  init
+
+  converge_if_changed do
+    nexus3_api "upsert_outbound_proxy #{new_resource.name}" do
+      script_name 'upsert_outbound_proxy'
+      args new_resource.config
+      action %i(create run)
+      api_client new_resource.api_client
+
+      content ::Nexus3::Scripts.groovy_content('upsert_outbound_proxy', node)
+    end
+  end
+end
+
+action :delete do
+  init
+
+  nexus3_api "delete_outbound_proxy #{new_resource.name}" do
+    action %i(create run)
+    script_name 'delete_outbound_proxy'
+    content ::Nexus3::Scripts.groovy_content('delete_outbound_proxy', node)
+
+    api_client new_resource.api_client
+
+    not_if { current_resource.nil? }
+  end
+end
+
+action_class do
+  def init
+    chef_gem 'httpclient' do
+      compile_time true
+    end
+
+    nexus3_api "get_outbound_proxy #{new_resource.name}" do
+      action :create
+      script_name 'get_outbound_proxy'
+      api_client new_resource.api_client
+
+      content ::Nexus3::Scripts.groovy_content('get_outbound_proxy', node)
+    end
+  end
+end

--- a/test/fixtures/cookbooks/nexus3_test/recipes/outbound_proxy.rb
+++ b/test/fixtures/cookbooks/nexus3_test/recipes/outbound_proxy.rb
@@ -1,0 +1,37 @@
+conf = Mash.new(
+  http: {
+    host: 'proxy.example.com',
+    port: 80,
+    auth: {
+      username: 'user',
+      password: 'secret',
+      host: 'ntlmhost',
+      domain: 'ntlmdom'
+    }
+  },
+  https: {
+    host: 'proxy-sec.example.com',
+    port: 443,
+    auth: {
+      username: 'usersec',
+      password: 'secretsec',
+      host: 'ntlmhostsec',
+      domain: 'ntlmdomsec'
+    }
+  },
+  non_proxy_hosts: ['rubygems.org', '*.chef.io']
+)
+
+nexus3_outbound_proxy 'fakeproxy' do
+  config conf
+end
+
+nexus3_outbound_proxy 'fakeproxy again' do
+  config conf
+  notifies :run, 'ruby_block[fail if fakeproxy is created again]', :immediately
+end
+
+ruby_block 'fail if fakeproxy is created again' do
+  action :nothing
+  block { raise 'nexus3_outbound_proxy is not idempotent!' }
+end


### PR DESCRIPTION
Outbound proxy can be configured by setting
node['nexus3']['outbound_proxy'] attribute.

http proxy, https proxy can have a different configurations.
non_proxy_hosts can be used to not proxy request for the given
hosts.

NOTE: If outbound_proxy attribute is removed, proxy configuration is
cleaned. Which means if you manually set a config but do not add the
corresping attributes, your config will be erased with this commit.