### PR TITLE
Bump nexus3 to 3.20 with fixed cleanup_policy script

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -6,7 +6,7 @@ else
   default['nexus3']['group'] = 'nexus'
 end
 # Download URL is defined in the resource but you can override it with the default['nexus3']['url'] attribute
-default['nexus3']['version'] = '3.19.1-01'
+default['nexus3']['version'] = '3.20.0-04'
 default['nexus3']['url'] = "https://download.sonatype.com/nexus/3/nexus-#{node['nexus3']['version']}-unix.tar.gz"
 default['nexus3']['checksum'] = nil # optional
 default['nexus3']['home'] = "#{node['nexus3']['path']}/nexus3"

--- a/files/default/upsert_cleanup_policy.3.20.groovy
+++ b/files/default/upsert_cleanup_policy.3.20.groovy
@@ -1,0 +1,26 @@
+import groovy.json.JsonSlurper
+import org.sonatype.nexus.cleanup.storage.CleanupPolicyStorage
+
+def params = new JsonSlurper().parseText(args)
+def policyStorage = container.lookup(CleanupPolicyStorage.class.getName()) as CleanupPolicyStorage
+
+def add = false
+def cleanupPolicy = policyStorage.get(params.name)
+if (!cleanupPolicy) {
+    cleanupPolicy = policyStorage.newCleanupPolicy()
+    cleanupPolicy.setName(params.name)
+    add = true
+}
+
+cleanupPolicy.setNotes(params.notes)
+cleanupPolicy.setFormat(params.format)
+cleanupPolicy.setMode(params.mode)
+cleanupPolicy.setCriteria(params.criteria)
+
+if (add) {
+    policyStorage.add(cleanupPolicy)
+} else {
+    policyStorage.update(cleanupPolicy)
+}
+
+return true

--- a/resources/cleanup_policy.rb
+++ b/resources/cleanup_policy.rb
@@ -24,6 +24,11 @@ end
 
 action :create do
   init
+  version = if ::Gem::Version.create(node['nexus3']['version'].split('-').first) >= ::Gem::Version.create('3.20.0')
+              '.3.20'
+            else
+              ''
+            end
 
   converge_if_changed do
     nexus3_api "upsert_cleanup_policy #{new_resource.policy_name}" do
@@ -37,7 +42,7 @@ action :create do
       action %i(create run)
       api_client new_resource.api_client
 
-      content ::Nexus3::Scripts.groovy_content('upsert_cleanup_policy', node)
+      content ::Nexus3::Scripts.groovy_content("upsert_cleanup_policy#{version}", node)
     end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,7 +2,7 @@ require 'chefspec'
 require 'chefspec/berkshelf'
 require 'webmock/rspec'
 
-VER = '3.19.1-01'.freeze
+VER = '3.20.0-04'.freeze
 CACHE = Chef::Config[:file_cache_path]
 CENTOS_VERSION = '7.4.1708'.freeze
 


### PR DESCRIPTION
* Bump nexus3 to 3.20.0, changelog:
  https://help.sonatype.com/repomanager3/release-notes/2019-release-notes#id-2019ReleaseNotes-RepositoryManager3.20.0
* Select correct upsert_cleanup_policy script depending
  on nexus3 version. Groovy API changed, CleanupPolicy  is now
  abstract and needs to be created via the CleanupPolicyStorage
  object.