### PR TITLE
Fix broken tests due to new version kitchen-inspec gem and java cookbook

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -18,5 +18,5 @@ end
 
 # Other gems should go after this comment
 gem 'faraday', '<0.16.0' # Newer version is incompatible with this cookbook.
-gem 'kitchen-inspec'
+gem 'kitchen-inspec', '!= 1.3.2'
 gem 'rubocop', '=0.47.1'

--- a/test/fixtures/cookbooks/nexus3_test/metadata.rb
+++ b/test/fixtures/cookbooks/nexus3_test/metadata.rb
@@ -7,4 +7,4 @@ long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 version '0.1.0'
 
 depends 'nexus3'
-depends 'java'
+depends 'java', '= 7.0.0'


### PR DESCRIPTION
- Java cookbook version 8 dropped the support with older Chef version.
- kitchen-inspec 1.3.2 broke the compatibility with inspec < 2 without changing the constraint
