### PR TITLE
Fix delete action on resources role, task, user & cleanup_policy

### DIFF
--- a/files/default/delete_cleanup_policy.groovy
+++ b/files/default/delete_cleanup_policy.groovy
@@ -2,7 +2,7 @@ import org.sonatype.nexus.cleanup.storage.CleanupPolicyStorage;
 import groovy.json.JsonOutput;
 
 def policyStorage = container.lookup(CleanupPolicyStorage.class.getName());
-if (policyStorage.exists?(args)) {
+if (policyStorage.exists(args)) {
   policyStorage.remove(policyStorage.get(args));
   return true;
 }

--- a/resources/cleanup_policy.rb
+++ b/resources/cleanup_policy.rb
@@ -50,18 +50,16 @@ end
 action :delete do
   init
 
-  converge_if_changed do
-    nexus3_api "delete_cleanup_policy #{new_resource.policy_name}" do
-      action %i[create run]
-      script_name 'delete_cleanup_policy'
-      args new_resource.policy_name
+  nexus3_api "delete_cleanup_policy #{new_resource.policy_name}" do
+    action %i[create run]
+    script_name 'delete_cleanup_policy'
+    args new_resource.policy_name
 
-      content ::Nexus3::Scripts.groovy_content('delete_cleanup_policy', node)
+    content ::Nexus3::Scripts.groovy_content('delete_cleanup_policy', node)
 
-      api_client new_resource.api_client
+    api_client new_resource.api_client
 
-      not_if { current_resource.nil? }
-    end
+    not_if { current_resource.nil? }
   end
 end
 

--- a/resources/role.rb
+++ b/resources/role.rb
@@ -40,16 +40,16 @@ end
 action :delete do
   init
 
-  converge_if_changed do
-    nexus3_api "delete_role #{new_resource.role_name}" do
-      script_name 'delete_role'
-      args new_resource.role_name
+  nexus3_api "delete_role #{new_resource.role_name}" do
+    script_name 'delete_role'
+    args new_resource.role_name
 
-      action %i[create run]
-      api_client new_resource.api_client
+    action %i[create run]
+    api_client new_resource.api_client
 
-      content ::Nexus3::Scripts.groovy_content('delete_role', node)
-    end
+    content ::Nexus3::Scripts.groovy_content('delete_role', node)
+
+    not_if { current_resource.nil? }
   end
 end
 

--- a/resources/task.rb
+++ b/resources/task.rb
@@ -38,18 +38,16 @@ end
 action :delete do
   init
 
-  converge_if_changed do
-    nexus3_api "delete_task #{new_resource.task_name}" do
-      action %i[create run]
-      script_name 'delete_task'
-      args new_resource.task_name
+  nexus3_api "delete_task #{new_resource.task_name}" do
+    action %i[create run]
+    script_name 'delete_task'
+    args new_resource.task_name
 
-      content ::Nexus3::Scripts.groovy_content('delete_task', node)
+    content ::Nexus3::Scripts.groovy_content('delete_task', node)
 
-      api_client new_resource.api_client
+    api_client new_resource.api_client
 
-      not_if { current_resource.nil? }
-    end
+    not_if { current_resource.nil? }
   end
 end
 

--- a/resources/user.rb
+++ b/resources/user.rb
@@ -61,6 +61,8 @@ action :delete do
     api_client new_resource.api_client
 
     content ::Nexus3::Scripts.groovy_content('delete_user', node)
+
+    not_if { current_resource.nil? }
   end
 end
 


### PR DESCRIPTION
In role, task & cleanup_policy the enclosing "converge_if_changed" was preventing the resource to actually delete the object when it exists.

In user & role the missing 'not_if' guard prevent the idempotency.

In the delete script for cleanup_policy, a typo has been introduced so the groovy code was incorrect.