### PR TITLE
Fix task resource to properly return the cron expression

### DIFF
--- a/files/default/get_task.groovy
+++ b/files/default/get_task.groovy
@@ -1,3 +1,4 @@
+import org.sonatype.nexus.scheduling.schedule.Schedule;
 import org.sonatype.nexus.scheduling.TaskConfiguration;
 import org.sonatype.nexus.scheduling.TaskInfo;
 import org.sonatype.nexus.scheduling.TaskScheduler;
@@ -11,5 +12,11 @@ TaskInfo existingTask = taskScheduler.listsTasks().find { TaskInfo taskInfo ->
 }
 
 if (existingTask) {
-    return JsonOutput.toJson(existingTask.getConfiguration().asMap());
+    Schedule schedule = existingTask.getSchedule();
+    Map<String, String> schedule_properties = new HashMap<>();
+    schedule_properties.put('type', schedule.getType());
+    if (schedule.getType() == 'cron') {
+      schedule_properties.put('cronExpression', schedule.getCronExpression());
+    }
+    return JsonOutput.toJson([ schedule: schedule_properties ] + existingTask.getConfiguration().asMap());
 }

--- a/resources/task.rb
+++ b/resources/task.rb
@@ -9,6 +9,7 @@ load_current_value do |desired|
     current_value_does_not_exist! if config.nil?
     ::Chef::Log.debug "Config is: #{config}"
     task_source config['source'] || ''.freeze
+    task_crontab config.dig('schedule', 'cronExpression') || ''.freeze
   # We rescue here because during the first run, the task will not exist yet, so we let Chef know that
   # the resource has to be created.
   rescue LoadError, ::Nexus3::ApiError => e


### PR DESCRIPTION
It seems we incorrectly implemented this resource, the schedule info were not retrieved at all.
We'll have to break the interface to support other task than cron.