### PR TITLE
Generic task resource to support all types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Unreleased
+
+- Task creation is now more generic. This change is breaking with any previous
+  usage of tasks. Please have a look at api_examples/task.rb for integration
+
 ## 3.6.0 2019-12-16
 
 - Knob to configure outbound proxy #106

--- a/api_examples/task.rb
+++ b/api_examples/task.rb
@@ -1,0 +1,150 @@
+nexus3_task 'Docker - Delete unused manifests and images' do
+  task_type 'repository.docker.gc'
+  task_crontab '0 0 1 * * ?'
+  properties {'repositoryName' => 'repository_name'}
+end
+
+nexus3_task 'Docker - Delete incomplete uploads' do
+  task_type 'repository.docker.upload-purge'
+  task_crontab '0 0 1 * * ?'
+  properties {'age' => 1234}
+end
+
+nexus3_task 'Admin - Cleanup repositories using their associated policies' do
+  task_type 'repository.cleanup'
+  task_crontab '0 0 1 * * ?'
+end
+
+nexus3_task 'Storage facet cleanup' do
+  task_type 'repository.storage-facet-cleanup'
+  task_crontab '0 0 1 * * ?'
+end
+
+nexus3_task 'Repository - Delete unused components' do
+  task_type 'repository.docker.upload-purge'
+  task_crontab '0 0 1 * * ?'
+  properties {'repositoryName' => 'repository_name','lastUsed' => 123}
+end
+
+nexus3_task 'Repair - Rebuild Maven repository metadata (maven-metadata.xml)' do
+  task_type 'repository.maven.rebuild-metadata'
+  task_crontab '0 0 1 * * ?'
+  properties {'repositoryName' => 'repository_name',
+              'groupId' => 'group',
+              'artifactId' => 'artifact',
+              'baseVersion' => 'version',
+              'rebuildChecksums' => false }
+end
+
+nexus3_task 'Check for new report availability' do
+  task_type 'healthcheck'
+  task_crontab '0 0 1 * * ?'
+end
+
+nexus3_task 'Repair - Rebuild Yum repository metadata (repodata)' do
+  task_type 'repository.yum.rebuild.metadata'
+  task_crontab '0 0 1 * * ?'
+  properties {'repositoryName' => 'repository_name',
+              'yumMetadataCaching' => false}
+end
+
+nexus3_task 'Repository Audit' do
+  task_type 'firewall.audit'
+  task_crontab '0 0 1 * * ?'
+end
+
+nexus3_task 'Task log cleanup' do
+  task_type 'tasklog.cleanup'
+  task_crontab '0 0 1 * * ?'
+end
+
+nexus3_task 'Maven - Publish Maven Indexer files' do
+  task_type 'repository.maven.publish-dotindex'
+  task_crontab '0 0 1 * * ?'
+  properties {'repositoryName' => 'repository_name'}
+end
+
+nexus3_task 'Repair - Reconcile npm /-/v1/search metadata' do
+  task_type 'repository.npm.reindex'
+  task_crontab '0 0 1 * * ?'
+  properties {'repositoryName' => 'repository_name'}
+end
+
+nexus3_task 'Repair - Rebuild repository browse' do
+  task_type 'create.browse.nodes'
+    task_crontab '0 0 1 * * ?'
+  properties {'repositoryName' => 'repository_name'}
+end
+
+nexus3_task 'Repair - Reconcile component database from blob store' do
+  task_type 'blobstore.rebuildComponentDB'
+  task_crontab '0 0 1 * * ?'
+  properties {'blobstoreName' => 'blob_store_name',
+              'dryRun' => false,
+              'restoreBlobs' => false,
+              'undeleteBlobs' => false,
+              'integrityCheck' => false}
+end
+
+nexus3_task 'Maven - Delete SNAPSHOT' do
+  task_type 'repository.maven.remove-snapshots'
+  task_crontab '0 0 1 * * ?'
+  properties {'repositoryName' => 'repository_name',
+              'minimumRetained' => 123,
+              'snapshotRetentionDays' => 123,
+              'removeIfReleased' => false,
+              'gracePeriodInDays' => 123 }
+end
+
+nexus3_task 'Maven - Delete unused SNAPSHOT' do
+  task_type 'repository.maven.purge-unused-snapshots'
+  task_crontab '0 0 1 * * ?'
+  properties {'repositoryName' => 'repository_name',
+              'lastUsed' => 123}
+end
+
+nexus3_task 'Admin - Compact blob store' do
+  task_type 'blobstore.compact'
+  task_crontab '0 0 1 * * ?'
+  properties {'blobstoreName' => 'blob_store_name'}
+end
+
+nexus3_task 'Maven - Unpublish Maven Indexer files' do
+  task_type 'repository.maven.unpublish-dotindex'
+  task_crontab '0 0 1 * * ?'
+  properties {'repositoryName' => 'repository_name'}
+end
+
+nexus3_task 'Firewall ignore patterns' do
+  task_type 'firewall.ignore-patterns'
+  task_crontab '0 0 1 * * ?'
+end
+
+nexus3_task 'Admin - Execute script' do
+  task_type 'script'
+  task_crontab '0 0 1 * * ?'
+  properties {'language' => 'lang',
+              'source' => 'script source'}
+end
+
+nexus3_task 'Repair - Reconcile date metadata from blob store' do
+  task_type 'rebuild.asset.uploadMetadata'
+  task_crontab '0 0 1 * * ?'
+end
+
+nexus3_task 'Admin - Delete orphaned API keys' do
+  task_type 'security.purge-api-keys'
+  task_crontab '0 0 1 * * ?'
+end
+
+nexus3_task 'Repair - Rebuild repository search' do
+  task_type'repository.rebuild-index'
+  task_crontab '0 0 1 * * ?'
+  properties {'repositoryName' => 'repository_name'}
+end
+
+nexus3_task 'Admin - Export databases for backup' do
+  task_type 'db.backup'
+  task_crontab '0 0 1 * * ?'
+  properties {'location' => 'backup_location'}
+end

--- a/api_examples/task.rb
+++ b/api_examples/task.rb
@@ -1,150 +1,151 @@
 nexus3_task 'Docker - Delete unused manifests and images' do
   task_type 'repository.docker.gc'
-  task_crontab '0 0 1 * * ?'
-  properties {'repositoryName' => 'repository_name'}
+  crontab '0 0 1 * * ?'
+  properties({ 'repositoryName' => 'repository_name' })
 end
 
 nexus3_task 'Docker - Delete incomplete uploads' do
   task_type 'repository.docker.upload-purge'
-  task_crontab '0 0 1 * * ?'
-  properties {'age' => 1234}
+  crontab '0 0 1 * * ?'
+  properties({ 'age' => 1234 })
 end
 
 nexus3_task 'Admin - Cleanup repositories using their associated policies' do
   task_type 'repository.cleanup'
-  task_crontab '0 0 1 * * ?'
+  crontab '0 0 1 * * ?'
 end
 
 nexus3_task 'Storage facet cleanup' do
   task_type 'repository.storage-facet-cleanup'
-  task_crontab '0 0 1 * * ?'
+  crontab '0 0 1 * * ?'
 end
 
 nexus3_task 'Repository - Delete unused components' do
   task_type 'repository.docker.upload-purge'
-  task_crontab '0 0 1 * * ?'
-  properties {'repositoryName' => 'repository_name','lastUsed' => 123}
+  crontab '0 0 1 * * ?'
+  properties({ 'repositoryName' => 'repository_name',
+               'lastUsed' => 123 })
 end
 
 nexus3_task 'Repair - Rebuild Maven repository metadata (maven-metadata.xml)' do
   task_type 'repository.maven.rebuild-metadata'
-  task_crontab '0 0 1 * * ?'
-  properties {'repositoryName' => 'repository_name',
-              'groupId' => 'group',
-              'artifactId' => 'artifact',
-              'baseVersion' => 'version',
-              'rebuildChecksums' => false }
+  crontab '0 0 1 * * ?'
+  properties({ 'repositoryName' => 'repository_name',
+               'groupId' => 'group',
+               'artifactId' => 'artifact',
+               'baseVersion' => 'version',
+               'rebuildChecksums' => false })
 end
 
 nexus3_task 'Check for new report availability' do
   task_type 'healthcheck'
-  task_crontab '0 0 1 * * ?'
+  crontab '0 0 1 * * ?'
 end
 
 nexus3_task 'Repair - Rebuild Yum repository metadata (repodata)' do
   task_type 'repository.yum.rebuild.metadata'
-  task_crontab '0 0 1 * * ?'
-  properties {'repositoryName' => 'repository_name',
-              'yumMetadataCaching' => false}
+  crontab '0 0 1 * * ?'
+  properties({ 'repositoryName' => 'repository_name',
+               'yumMetadataCaching' => false })
 end
 
 nexus3_task 'Repository Audit' do
   task_type 'firewall.audit'
-  task_crontab '0 0 1 * * ?'
+  crontab '0 0 1 * * ?'
 end
 
 nexus3_task 'Task log cleanup' do
   task_type 'tasklog.cleanup'
-  task_crontab '0 0 1 * * ?'
+  crontab '0 0 1 * * ?'
 end
 
 nexus3_task 'Maven - Publish Maven Indexer files' do
   task_type 'repository.maven.publish-dotindex'
-  task_crontab '0 0 1 * * ?'
-  properties {'repositoryName' => 'repository_name'}
+  crontab '0 0 1 * * ?'
+  properties({ 'repositoryName' => 'repository_name' })
 end
 
 nexus3_task 'Repair - Reconcile npm /-/v1/search metadata' do
   task_type 'repository.npm.reindex'
-  task_crontab '0 0 1 * * ?'
-  properties {'repositoryName' => 'repository_name'}
+  crontab '0 0 1 * * ?'
+  properties({ 'repositoryName' => 'repository_name' })
 end
 
 nexus3_task 'Repair - Rebuild repository browse' do
   task_type 'create.browse.nodes'
-    task_crontab '0 0 1 * * ?'
-  properties {'repositoryName' => 'repository_name'}
+  crontab '0 0 1 * * ?'
+  properties({ 'repositoryName' => 'repository_name' })
 end
 
 nexus3_task 'Repair - Reconcile component database from blob store' do
   task_type 'blobstore.rebuildComponentDB'
-  task_crontab '0 0 1 * * ?'
-  properties {'blobstoreName' => 'blob_store_name',
-              'dryRun' => false,
-              'restoreBlobs' => false,
-              'undeleteBlobs' => false,
-              'integrityCheck' => false}
+  crontab '0 0 1 * * ?'
+  properties({ 'blobstoreName' => 'blob_store_name',
+               'dryRun' => false,
+               'restoreBlobs' => false,
+               'undeleteBlobs' => false,
+               'integrityCheck' => false })
 end
 
 nexus3_task 'Maven - Delete SNAPSHOT' do
   task_type 'repository.maven.remove-snapshots'
-  task_crontab '0 0 1 * * ?'
-  properties {'repositoryName' => 'repository_name',
-              'minimumRetained' => 123,
-              'snapshotRetentionDays' => 123,
-              'removeIfReleased' => false,
-              'gracePeriodInDays' => 123 }
+  crontab '0 0 1 * * ?'
+  properties({ 'repositoryName' => 'repository_name',
+               'minimumRetained' => 123,
+               'snapshotRetentionDays' => 123,
+               'removeIfReleased' => false,
+               'gracePeriodInDays' => 123 })
 end
 
 nexus3_task 'Maven - Delete unused SNAPSHOT' do
   task_type 'repository.maven.purge-unused-snapshots'
-  task_crontab '0 0 1 * * ?'
-  properties {'repositoryName' => 'repository_name',
-              'lastUsed' => 123}
+  crontab '0 0 1 * * ?'
+  properties({ 'repositoryName' => 'repository_name',
+               'lastUsed' => 123 })
 end
 
 nexus3_task 'Admin - Compact blob store' do
   task_type 'blobstore.compact'
-  task_crontab '0 0 1 * * ?'
-  properties {'blobstoreName' => 'blob_store_name'}
+  crontab '0 0 1 * * ?'
+  properties({ 'blobstoreName' => 'blob_store_name' })
 end
 
 nexus3_task 'Maven - Unpublish Maven Indexer files' do
   task_type 'repository.maven.unpublish-dotindex'
-  task_crontab '0 0 1 * * ?'
-  properties {'repositoryName' => 'repository_name'}
+  crontab '0 0 1 * * ?'
+  properties({ 'repositoryName' => 'repository_name' })
 end
 
 nexus3_task 'Firewall ignore patterns' do
   task_type 'firewall.ignore-patterns'
-  task_crontab '0 0 1 * * ?'
+  crontab '0 0 1 * * ?'
 end
 
 nexus3_task 'Admin - Execute script' do
   task_type 'script'
-  task_crontab '0 0 1 * * ?'
-  properties {'language' => 'lang',
-              'source' => 'script source'}
+  crontab '0 0 1 * * ?'
+  properties({ 'language' => 'lang',
+               'source' => 'script source' })
 end
 
 nexus3_task 'Repair - Reconcile date metadata from blob store' do
   task_type 'rebuild.asset.uploadMetadata'
-  task_crontab '0 0 1 * * ?'
+  crontab '0 0 1 * * ?'
 end
 
 nexus3_task 'Admin - Delete orphaned API keys' do
   task_type 'security.purge-api-keys'
-  task_crontab '0 0 1 * * ?'
+  crontab '0 0 1 * * ?'
 end
 
 nexus3_task 'Repair - Rebuild repository search' do
-  task_type'repository.rebuild-index'
-  task_crontab '0 0 1 * * ?'
-  properties {'repositoryName' => 'repository_name'}
+  task_type 'repository.rebuild-index'
+  crontab '0 0 1 * * ?'
+  properties({ 'repositoryName' => 'repository_name' })
 end
 
 nexus3_task 'Admin - Export databases for backup' do
   task_type 'db.backup'
-  task_crontab '0 0 1 * * ?'
-  properties {'location' => 'backup_location'}
+  crontab '0 0 1 * * ?'
+  properties({ 'location' => 'backup_location' })
 end

--- a/files/default/upsert_task.groovy
+++ b/files/default/upsert_task.groovy
@@ -17,9 +17,11 @@ if (existingTask && !existingTask.remove()) {
     throw new RuntimeException("Could not remove currently running task: " + params.name);
 }
 
-TaskConfiguration taskConfiguration = taskScheduler.createTaskConfigurationInstance('script');
+TaskConfiguration taskConfiguration = taskScheduler.createTaskConfigurationInstance(params.typeId);
 taskConfiguration.setName(params.name);
-taskConfiguration.setString('source', params.source);
+
+params.taskProperties.each { key, value -> taskConfiguration.setString(key, value) };
+
 Schedule schedule = taskScheduler.scheduleFactory.cron(new Date(), params.crontab);
 
 taskScheduler.scheduleTask(taskConfiguration, schedule);

--- a/resources/task.rb
+++ b/resources/task.rb
@@ -40,9 +40,8 @@ load_current_value do |desired|
     ::Chef::Log.debug "Config is: #{config}"
     crontab config.dig('schedule', 'cronExpression') || ''.freeze
     task_type config['.typeId'] || ''.freeze
-    config['properties'].nil? || config['properties'].each do |key, value|
-      properties[key] = value
-    end
+    # Only care about properties we are setting
+    properties(config.keep_if { |k, _| desired.properties.keys.include?(k) })
 
   # We rescue here because during the first run, the task will not exist yet, so we let Chef know that
   # the resource has to be created.

--- a/resources/task.rb
+++ b/resources/task.rb
@@ -40,7 +40,7 @@ load_current_value do |desired|
     ::Chef::Log.debug "Config is: #{config}"
     crontab config.dig('schedule', 'cronExpression') || ''.freeze
     task_type config['.typeId'] || ''.freeze
-    config['properties'].each do |key, value|
+    config['properties'].nil? || config['properties'].each do |key, value|
       properties[key] = value
     end
 

--- a/test/fixtures/cookbooks/nexus3_resources_test/attributes/task.rb
+++ b/test/fixtures/cookbooks/nexus3_resources_test/attributes/task.rb
@@ -1,9 +1,13 @@
 # Test task resource
 # action: create
 default['nexus3_resources_test']['task']['create']['default']['task_name'] = 'bask'
+default['nexus3_resources_test']['task']['create']['default']['task_type'] = 'script'
+
 # Test task update
 default['nexus3_resources_test']['task']['create']['update_with_properties']['task_name'] = 'bask'
-default['nexus3_resources_test']['task']['create']['update_with_properties']['task_source'] = 'InvalidCode'
-default['nexus3_resources_test']['task']['create']['update_with_properties']['task_crontab'] = '0 2 * * * ?'
+default['nexus3_resources_test']['task']['create']['update_with_properties']['task_type'] = 'script'
+default['nexus3_resources_test']['task']['create']['update_with_properties']['crontab'] = '0 2 * * * ?'
+default['nexus3_resources_test']['task']['create']['update_with_properties']['properties'] = {'language' => 'lang', 'source' => 'log.info("Hello task");'}
+
 # action :delete
 default['nexus3_resources_test']['task']['delete']['default']['task_name'] = 'bask'

--- a/test/fixtures/cookbooks/nexus3_resources_test/attributes/task.rb
+++ b/test/fixtures/cookbooks/nexus3_resources_test/attributes/task.rb
@@ -3,11 +3,16 @@
 default['nexus3_resources_test']['task']['create']['default']['task_name'] = 'bask'
 default['nexus3_resources_test']['task']['create']['default']['task_type'] = 'script'
 
+default['nexus3_resources_test']['task']['create']['compact']['task_name'] = 'compact_default'
+default['nexus3_resources_test']['task']['create']['compact']['task_type'] = 'blobstore.compact'
+default['nexus3_resources_test']['task']['create']['compact']['crontab'] = '0 15 4 * * ?'
+default['nexus3_resources_test']['task']['create']['compact']['properties'] = { 'blobstoreName' => 'default' }
+
 # Test task update
 default['nexus3_resources_test']['task']['create']['update_with_properties']['task_name'] = 'bask'
 default['nexus3_resources_test']['task']['create']['update_with_properties']['task_type'] = 'script'
 default['nexus3_resources_test']['task']['create']['update_with_properties']['crontab'] = '0 2 * * * ?'
-default['nexus3_resources_test']['task']['create']['update_with_properties']['properties'] = {'language' => 'lang', 'source' => 'log.info("Hello task");'}
+default['nexus3_resources_test']['task']['create']['update_with_properties']['properties'] = { 'language' => 'lang', 'source' => 'log.info("Hello task");' }
 
 # action :delete
 default['nexus3_resources_test']['task']['delete']['default']['task_name'] = 'bask'

--- a/test/fixtures/cookbooks/nexus3_test/recipes/integration.rb
+++ b/test/fixtures/cookbooks/nexus3_test/recipes/integration.rb
@@ -25,9 +25,12 @@ nexus3_role 'integration_role' do
 end
 
 nexus3_task 'integration_task' do
+  task_type 'script'
   task_crontab '0 2 * * * ?'
-  task_source 'log.info("Hello task");'
+  task_properties {'language' => 'lang',
+              'source' => 'log.info("Hello task");'}
 end
+
 
 nexus3_user 'integration_user' do
   password 'Secret'

--- a/test/fixtures/cookbooks/nexus3_test/recipes/integration.rb
+++ b/test/fixtures/cookbooks/nexus3_test/recipes/integration.rb
@@ -26,11 +26,10 @@ end
 
 nexus3_task 'integration_task' do
   task_type 'script'
-  task_crontab '0 2 * * * ?'
-  task_properties {'language' => 'lang',
-              'source' => 'log.info("Hello task");'}
+  crontab '0 2 * * * ?'
+  properties({ 'language' => 'lang',
+               'source' => 'log.info("Hello task");' })
 end
-
 
 nexus3_user 'integration_user' do
   password 'Secret'


### PR DESCRIPTION
Previous task resource permitted only `script` tasks. Make the resource
more generic so any kind of task can be created.

Usage examples can be found in `api_examples/task.rb`.

Since there is a lot of task types, i didn't created a chef resource for each one. Instead, you need to pass the task's typeId and other properties in a hash with specific keys, according to the desired task.