### PR TITLE
Adding port forwarding for kitchen_dokken

### DIFF
--- a/.kitchen.docker.yml
+++ b/.kitchen.docker.yml
@@ -46,6 +46,9 @@ suites:
     - nexus3_test::default
     - nexus3_resources_test::default
     - nexus3_test::integration
+  ports:
+    - 8081
+    - 8082
   attributes:
     nexus3_test:
       connection_retries: 10


### PR DESCRIPTION
- Exposed the port 8081 and 8082, in order to access the nexus
  repositories during local kitchen-dokken tests for debugging purposes

Signed-off-by: Jeremy MAURO <j.mauro@criteo.com>