### PR TITLE
Install httpclient via cookbook metadata gem dependency

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -19,3 +19,5 @@ supports 'fedora'
 supports 'redhat'
 supports 'ubuntu'
 supports 'windows'
+
+gem 'httpclient', '>= 2.8'

--- a/resources/api.rb
+++ b/resources/api.rb
@@ -14,8 +14,6 @@ load_current_value do |desired|
 end
 
 action :create do
-  chef_gem 'httpclient'
-
   converge_if_changed do
     new_resource.api_client.request(:delete, new_resource.script_name) unless current_resource.nil?
     new_resource.api_client.request(:post, '', 'application/json', name: new_resource.script_name, type: 'groovy',
@@ -24,16 +22,12 @@ action :create do
 end
 
 action :run do
-  chef_gem 'httpclient'
-
   converge_by "running script #{new_resource.script_name}" do
     new_resource.api_client.run_script(new_resource.script_name, new_resource.args)
   end
 end
 
 action :delete do
-  chef_gem 'httpclient'
-
   unless current_resource.nil?
     converge_by "deleting script #{new_resource.script_name}" do
       new_resource.api_client.request(:delete, new_resource.script_name)

--- a/resources/cleanup_policy.rb
+++ b/resources/cleanup_policy.rb
@@ -65,10 +65,6 @@ end
 
 action_class do
   def init
-    chef_gem 'httpclient' do
-      compile_time true
-    end
-
     nexus3_api "get_cleanup_policy #{new_resource.policy_name}" do
       action :create
       script_name 'get_cleanup_policy'

--- a/resources/outbound_proxy.rb
+++ b/resources/outbound_proxy.rb
@@ -46,10 +46,6 @@ end
 
 action_class do
   def init
-    chef_gem 'httpclient' do
-      compile_time true
-    end
-
     nexus3_api "get_outbound_proxy #{new_resource.name}" do
       action :create
       script_name 'get_outbound_proxy'

--- a/resources/realm.rb
+++ b/resources/realm.rb
@@ -34,10 +34,6 @@ end
 
 action_class do
   def init
-    chef_gem 'httpclient' do
-      compile_time true
-    end
-
     nexus3_api "get_realm_status #{new_resource.realm_name}" do
       action :create
       script_name 'get_realm_status'

--- a/resources/repo.rb
+++ b/resources/repo.rb
@@ -59,10 +59,6 @@ end
 
 action_class do
   def init
-    chef_gem 'httpclient' do
-      compile_time true
-    end
-
     nexus3_api "get_repo #{new_resource.repo_name}" do
       action :create
       script_name 'get_repo'

--- a/resources/role.rb
+++ b/resources/role.rb
@@ -55,10 +55,6 @@ end
 
 action_class do
   def init
-    chef_gem 'httpclient' do
-      compile_time true
-    end
-
     nexus3_api 'get_role' do
       action :create
       api_client new_resource.api_client

--- a/resources/task.rb
+++ b/resources/task.rb
@@ -54,10 +54,6 @@ end
 
 action_class do
   def init
-    chef_gem 'httpclient' do
-      compile_time true
-    end
-
     nexus3_api "get_task #{new_resource.task_name}" do
       action :create
       script_name 'get_task'

--- a/resources/user.rb
+++ b/resources/user.rb
@@ -68,10 +68,6 @@ end
 
 action_class do
   def init
-    chef_gem 'httpclient' do
-      compile_time true
-    end
-
     nexus3_api "get_user #{new_resource.username}" do
       action :create
       script_name 'get_user'


### PR DESCRIPTION
Instead of installing the gem in all nexus3_resource, lets install it globally when the cookbook is in the runlist.
This allows to have access to httpclient very early during Chef's run.

Replaces #83  and fixes #84