### PR TITLE
Coerce repositories attributes to ensure proper comparison

### DIFF
--- a/.kitchen.appveyor.yml
+++ b/.kitchen.appveyor.yml
@@ -9,7 +9,7 @@ driver:
 
 provisioner:
   name: chef_zero
-  require_chef_omnibus: 13.6.4
+  require_chef_omnibus: 14.7.17
 
 verifier:
   name: inspec

--- a/.kitchen.docker.yml
+++ b/.kitchen.docker.yml
@@ -2,7 +2,7 @@
 ---
 driver:
   name: dokken
-  chef_version: 13.6.4
+  chef_version: 14.7.17
   privileged: true # because Docker and SystemD/Upstart
 
 transport:

--- a/.kitchen.localhost.yml
+++ b/.kitchen.localhost.yml
@@ -4,7 +4,7 @@ driver:
 
 provisioner:
   name: chef_zero
-  require_chef_omnibus: 13.6.4
+  require_chef_omnibus: 14.7.17
 
 verifier:
   name: inspec

--- a/.kitchen.vmware.yml
+++ b/.kitchen.vmware.yml
@@ -8,7 +8,7 @@ driver:
 
 provisioner:
   name: chef_solo
-  require_chef_omnibus: 13.6.4
+  require_chef_omnibus: 14.7.17
 
 verifier:
   name: inspec

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -6,7 +6,7 @@ driver:
 
 provisioner:
   name: chef_solo
-  require_chef_omnibus: 13.6.4
+  require_chef_omnibus: 14.7.17
 
 verifier:
   name: inspec

--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,7 @@ source 'https://rubygems.org'
 gem 'berkshelf'
 
 group :unit_test do
-  gem 'chef', '= 13.12.14'
+  gem 'chef', '= 14.7.17'
   gem 'chefspec', '>= 7.4.0'
   gem 'fakefs'
   gem 'webmock'

--- a/libraries/nexus_helper.rb
+++ b/libraries/nexus_helper.rb
@@ -4,6 +4,17 @@ require 'net/http'
 module Nexus3
   # Helper library for testing Nexus3 responses
   module Helper
+    # Apply some logic on repo attributes hash
+    def self.coerce_repo_attributes(value)
+      value = value.dup
+      # Ensure cleanup policies are sorted if any, to ensure coherent comparison
+      if value.dig('cleanup', 'policyName')
+        value['cleanup'] = value['cleanup'].dup
+        value['cleanup']['policyName'] = value['cleanup']['policyName'].sort
+      end
+      value
+    end
+
     # Raise an error in case Nexus takes a really long time to start.
     class Nexus3NotReady < StandardError
       def initialize(endpoint, timeout)

--- a/resources/repo.rb
+++ b/resources/repo.rb
@@ -1,6 +1,6 @@
 property :repo_name, String, name_property: true
 property :repo_type, String, default: 'maven2-hosted'
-property :attributes, Hash, default: lazy { ::Mash.new } # Not mandatory but strongly recommended in the generic case.
+property :attributes, Hash, coerce: ::Nexus3::Helper.method(:coerce_repo_attributes), default: lazy { ::Mash.new }
 property :online, [true, false], default: true
 property :api_client, ::Nexus3::Api, identity: true, default: lazy { ::Nexus3::Api.default(node) }
 


### PR DESCRIPTION
The returned cleanup policies order may not be consistent.
As the order is not important here, we can sort the array to ensure the resource is comparing the value properly and in a consistent way.