### PR TITLE
Sorting cleanup policies attribute only if this is an Array

### DIFF
--- a/libraries/nexus_helper.rb
+++ b/libraries/nexus_helper.rb
@@ -8,7 +8,7 @@ module Nexus3
     def self.coerce_repo_attributes(value)
       value = value.dup
       # Ensure cleanup policies are sorted if any, to ensure coherent comparison
-      if value.dig('cleanup', 'policyName')
+      if value.dig('cleanup', 'policyName').is_a?(::Array)
         value['cleanup'] = value['cleanup'].dup
         value['cleanup']['policyName'] = value['cleanup']['policyName'].sort
       end


### PR DESCRIPTION
The nexus3_repo resource accept cleanup policies as string or array of strings.
The sort should only be applied on Arrays.