### PR TITLE
Add resource for routing-rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,8 +227,8 @@ end
 
 ## nexus3_api
 
-Configures Nexus 3 Repository Manager via API. Low-level resource, usually
-used within other resources.
+Configures Nexus 3 Repository Manager via Script API. Low-level resource,
+usually used within other resources.
 
 ### Actions
 - `:create` - Creates or updates the named script on the repository manager

--- a/README.md
+++ b/README.md
@@ -31,6 +31,9 @@ resource to configure Nexus 3 users.
 Use the [nexus3_realm](https://github.com/criteo-cookbooks/nexus3#nexus3_realm)
 resource to handle realm activation.
 
+Use the [nexus3_routing_rule](https://github.com/criteo-cookbooks/nexus3#nexus3_routing_rule)
+resource to configure Nexus 3 routing rules.
+
 ## Requirements
 * Chef 12.14.34+
 * ark cookbook
@@ -311,6 +314,23 @@ Handle realm activation via API.
 
 - `realm_name` - Name of realm to act on, defaults to resource name.
 - `enable` - Whether to enable a given realm.
+
+## nexus3_routing_rule
+
+Configures Nexus 3 [routing rules](https://help.sonatype.com/repomanager3/repository-management/routing-rules)
+via the REST API. Routing rules are used to restrict certain paths
+on proxy repositories.
+
+### Actions
+
+- `:create` - Creates or updates a routing rule.
+- `:delete` - Deletes a routing rule.
+
+### Properties
+
+- `description` - Rule description.
+- `mode` - Rule mode to ALLOW or BLOCK the given matchers, defaults to BLOCK.
+- `matchers` - A list of regex to identify paths to allow / block.
 
 ## nexus3_group
 

--- a/libraries/api.rb
+++ b/libraries/api.rb
@@ -15,7 +15,7 @@ module Nexus3
     end
 
     def self.endpoint(port)
-      "http://localhost:#{port}/service/rest/v1/script/"
+      "http://localhost:#{port}/service/rest/v1/"
     end
 
     def initialize(base_url, user, password)
@@ -69,8 +69,34 @@ module Nexus3
 
     # Runs a specific script with parameters
     def run_script(scriptname, params)
-      body = request(:post, "#{scriptname}/run", 'text/plain', params)
+      body = request(:post, "script/#{scriptname}/run", 'text/plain', params)
       JSON.parse(body)['result']
+    end
+
+    # Define rest methods to get and updates resources.
+    # single and many are used to name ruby methods.
+    [
+      %w[script script scripts]
+    ].each do |resource, single, many|
+      define_method(many) do
+        JSON.parse(request(:get, resource))
+      end
+
+      define_method(single) do |name|
+        JSON.parse(request(:get, "#{resource}/#{name}"))
+      end
+
+      define_method("delete_#{single}") do |name|
+        request(:delete, "#{resource}/#{name}")
+      end
+
+      define_method("add_#{single}") do |data|
+        request(:post, resource, 'application/json', data)
+      end
+
+      define_method("update_#{single}") do |data|
+        request(:put, "#{resource}/#{data['name']}", 'application/json', data)
+      end
     end
   end
 end

--- a/libraries/api.rb
+++ b/libraries/api.rb
@@ -76,7 +76,8 @@ module Nexus3
     # Define rest methods to get and updates resources.
     # single and many are used to name ruby methods.
     [
-      %w[script script scripts]
+      %w[script script scripts],
+      %w[routing-rules routing_rule routing_rules]
     ].each do |resource, single, many|
       define_method(many) do
         JSON.parse(request(:get, resource))

--- a/resources/api.rb
+++ b/resources/api.rb
@@ -5,7 +5,7 @@ property :api_client, ::Nexus3::Api, identity: true, default: lazy { ::Nexus3::A
 
 load_current_value do |desired|
   begin
-    response = JSON.parse(api_client.request(:get, desired.script_name))
+    response = api_client.script(desired.script_name)
     content response['content'] if response.is_a?(Hash) && response.key?('content')
   rescue LoadError, ::Nexus3::ApiError => e
     ::Chef::Log.warn "A '#{e.class}' occured: #{e.message}"
@@ -15,9 +15,8 @@ end
 
 action :create do
   converge_if_changed do
-    new_resource.api_client.request(:delete, new_resource.script_name) unless current_resource.nil?
-    new_resource.api_client.request(:post, '', 'application/json', name: new_resource.script_name, type: 'groovy',
-                                                                   content: new_resource.content)
+    new_resource.api_client.delete_script(new_resource.script_name) unless current_resource.nil?
+    new_resource.api_client.add_script(name: new_resource.script_name, type: 'groovy', content: new_resource.content)
   end
 end
 
@@ -30,7 +29,7 @@ end
 action :delete do
   unless current_resource.nil?
     converge_by "deleting script #{new_resource.script_name}" do
-      new_resource.api_client.request(:delete, new_resource.script_name)
+      new_resource.api_client.delete_script(new_resource.script_name)
     end
   end
 end

--- a/resources/routing_rule.rb
+++ b/resources/routing_rule.rb
@@ -1,0 +1,49 @@
+property :rule_name, ::String, name_property: true
+property :description, ::String, default: ''.freeze
+property :mode, ::String, equal_to: %w[BLOCK ALLOW], default: 'BLOCK'.freeze
+property :matchers, Array, default: lazy { [] }, coerce: proc { |m| m.sort }
+property :api_client, ::Nexus3::Api, identity: true, default: lazy { ::Nexus3::Api.default(node) }
+
+load_current_value do |desired|
+  begin
+    config = api_client.routing_rule(desired.rule_name)
+    current_value_does_not_exist! if config.nil?
+    ::Chef::Log.debug "Config is: #{config}"
+    description config['description']
+    mode config['mode']
+    matchers config['matchers']
+  # We rescue here because during the first run, the policy will not exist yet, so we let Chef know that
+  # the resource has to be created.
+  rescue ::LoadError, ::Nexus3::ApiError => e
+    ::Chef::Log.warn "A '#{e.class}' occured: #{e.message}"
+    current_value_does_not_exist!
+  end
+end
+
+action :create do
+  converge_if_changed do
+    converge_by("#{current_resource.nil? ? 'Creating' : 'Updating'} routing rule #{new_resource.rule_name}") do
+      method = current_resource.nil? ? 'add' : 'update'
+      new_resource.api_client.public_send("#{method}_routing_rule", {
+                                            'name' => new_resource.rule_name,
+                                            'description' => new_resource.description,
+                                            'mode' => new_resource.mode,
+                                            'matchers' => new_resource.matchers
+                                          })
+    end
+  end
+end
+
+action :delete do
+  unless current_resource.nil?
+    converge_by("Deleting routing rule #{new_resource.rule_name}") do
+      new_resource.api_client.delete_routing_rule(new_resource.rule_name)
+    end
+  end
+end
+
+action_class do
+  def whyrun_supported?
+    true
+  end
+end

--- a/test/fixtures/cookbooks/nexus3_resources_test/attributes/routing_rule.rb
+++ b/test/fixtures/cookbooks/nexus3_resources_test/attributes/routing_rule.rb
@@ -1,0 +1,11 @@
+# Test routing_rule resource
+#  action: create
+default['nexus3_resources_test']['routing_rule']['create']['default']['name'] = 'blockindex'
+default['nexus3_resources_test']['routing_rule']['create']['default']['mode'] = 'BLOCK'
+default['nexus3_resources_test']['routing_rule']['create']['default']['matchers'] = ['.*/index']
+# Test update
+default['nexus3_resources_test']['routing_rule']['create']['add_matcher']['name'] = 'blockindex'
+default['nexus3_resources_test']['routing_rule']['create']['add_matcher']['mode'] = 'BLOCK'
+default['nexus3_resources_test']['routing_rule']['create']['add_matcher']['matchers'] = ['.*/index', '.*/index.htm']
+#  action: delete
+default['nexus3_resources_test']['routing_rule']['delete']['delete_rule']['name'] = 'blockindex'

--- a/test/fixtures/cookbooks/nexus3_test/attributes/default.rb
+++ b/test/fixtures/cookbooks/nexus3_test/attributes/default.rb
@@ -1,6 +1,6 @@
 default['nexus3']['api']['username'] = 'admin'
 default['nexus3']['api']['password'] = 'admin123'
-default['nexus3']['api']['endpoint'] = 'http://localhost:8081/service/rest/v1/script/'
+default['nexus3']['api']['endpoint'] = 'http://localhost:8081/service/rest/v1/'
 
 default['java']['install_flavor'] = 'openjdk'
 default['java']['jdk_version'] = '8'


### PR DESCRIPTION
Routing rules can be used by proxy repo to restrict access to certain paths.

https://help.sonatype.com/repomanager3/repository-management/routing-rules

This pull request is breaking if you changed `default['nexus3']['api']['endpoint']` in your attributes. You'll need to remove `script/`
If you used ::Nexus3::Api.run_script / ::Nexus3::Api.request directly, you'll need to prepend the path with `script/`