### PR TITLE
Allow linking routing rule to repository

### DIFF
--- a/files/default/get_repo.groovy
+++ b/files/default/get_repo.groovy
@@ -1,10 +1,23 @@
 import groovy.json.JsonOutput
+import org.sonatype.nexus.repository.routing.RoutingRule
+import org.sonatype.nexus.repository.routing.RoutingRuleStore
+
 conf = repository.repositoryManager.get(args)?.getConfiguration()
 if (conf != null) {
+    String routingRuleName;
+    if (conf.getRoutingRuleId() != null) {
+      RoutingRuleStore routingRuleStore = container.lookup(RoutingRuleStore.class.getName());
+      routingRule = routingRuleStore.getById(conf.getRoutingRuleId().getValue())
+      if (routingRule != null) {
+        routingRuleName = routingRule.name()
+      }
+    }
+
     JsonOutput.toJson([
             repositoryName: conf.getRepositoryName(),
             recipeName: conf.getRecipeName(),
             online: conf.isOnline(),
-            attributes: conf.getAttributes()
+            attributes: conf.getAttributes(),
+            routingRuleName: routingRuleName
         ])
 }

--- a/resources/repo.rb
+++ b/resources/repo.rb
@@ -2,6 +2,7 @@ property :repo_name, String, name_property: true
 property :repo_type, String, default: 'maven2-hosted'
 property :attributes, Hash, coerce: ::Nexus3::Helper.method(:coerce_repo_attributes), default: lazy { ::Mash.new }
 property :online, [true, false], default: true
+property :routing_rule_name, String, default: ''
 property :api_client, ::Nexus3::Api, identity: true, default: lazy { ::Nexus3::Api.default(node) }
 
 load_current_value do |desired|
@@ -13,6 +14,7 @@ load_current_value do |desired|
     repo_type config['recipeName']
     attributes config['attributes']
     online config['online']
+    routing_rule_name config['routingRuleName']
   # We rescue here because during the first run, the repository will not exist yet, so we let Chef know that
   # the resource has to be created.
   rescue LoadError, ::Nexus3::ApiError => e
@@ -31,6 +33,7 @@ action :create do
            type: new_resource.repo_type,
            online: new_resource.online,
            attributes: new_resource.attributes,
+           routingRuleName: new_resource.routing_rule_name,
            multi_policy_cleanup_support: Gem::Version.new(node['nexus3']['version'].split('-').first) >=
                                          Gem::Version.new('3.19.0')
 

--- a/test/fixtures/cookbooks/nexus3_resources_test/attributes/repo.rb
+++ b/test/fixtures/cookbooks/nexus3_resources_test/attributes/repo.rb
@@ -1,9 +1,15 @@
 # Test repo resource
 default_repo_conf = ::Mash.new(storage: { blobStoreName: 'default', writePolicy: 'ALLOW_ONCE' })
 default_maven_conf = default_repo_conf.merge(maven: { versionPolicy: 'RELEASE', layoutPolicy: 'STRICT' })
+default_maven_proxy_conf = default_maven_conf.merge('maven-indexer': {}, proxy: { remoteUrl: 'http://localhost:8081' }, httpclient: {}, negativeCache: {})
 #  action: create
 default['nexus3_resources_test']['repo']['create']['maven']['repo_name'] = 'foo_maven'
 default['nexus3_resources_test']['repo']['create']['maven']['repo_type'] = 'maven2-hosted'
 default['nexus3_resources_test']['repo']['create']['maven']['attributes'] = default_maven_conf
+default['nexus3_resources_test']['repo']['create']['maven-proxy']['repo_name'] = 'foo_maven_proxy'
+default['nexus3_resources_test']['repo']['create']['maven-proxy']['repo_type'] = 'maven2-proxy'
+default['nexus3_resources_test']['repo']['create']['maven-proxy']['attributes'] = default_maven_proxy_conf
+default['nexus3_resources_test']['repo']['create']['maven-proxy']['routing_rule_name'] = 'mavenrule'
 #  action: delete
 default['nexus3_resources_test']['repo']['delete']['maven']['repo_name'] = 'foo_maven'
+default['nexus3_resources_test']['repo']['delete']['maven-proxy']['repo_name'] = 'foo_maven_proxy'

--- a/test/fixtures/cookbooks/nexus3_resources_test/recipes/default.rb
+++ b/test/fixtures/cookbooks/nexus3_resources_test/recipes/default.rb
@@ -1,4 +1,5 @@
 include_recipe 'nexus3_test'
+include_recipe '::dependencies'
 
 tested_resources = {}
 node['nexus3_resources_test'].each do |resource_name, actions|

--- a/test/fixtures/cookbooks/nexus3_resources_test/recipes/dependencies.rb
+++ b/test/fixtures/cookbooks/nexus3_resources_test/recipes/dependencies.rb
@@ -1,0 +1,5 @@
+# Create any resource on which you want other resources to depend on
+# but cannot guarantee run order.
+nexus3_routing_rule 'mavenrule' do
+  matchers ['.*/latest$']
+end


### PR DESCRIPTION
We cannot use attributes to associated a routing rule, so
we must use a separate param, like online.

The groovy scripts need to be updated, to retrieve the routing
rule ID when linked it, and its name when fetching the repo infos.

Adding a depencies recipe, so we can create resources that can be
reused in resources test. (Lost too much time on it already, so maybe
at some point I'll look into custom ordering the generated resources
to not have another recipe)