### PR TITLE
Fix user deletion to work without password

### DIFF
--- a/resources/user.rb
+++ b/resources/user.rb
@@ -17,11 +17,13 @@ load_current_value do |desired|
     roles config['roles']
 
     # Check if we need to change the password.
-    begin
-      ::Nexus3::Api.new(api_client.endpoint, username, desired.password).request(:get, '/service/metrics/ping')
-      password 'Supercalifragilisticexpialidocious-that-does-not-exist-so-maybe-the-resource-will-need-to-converge'
-    rescue ::Nexus3::ApiError
-      password desired.password
+    if self.class.properties[:password].is_set?(desired)
+      begin
+        ::Nexus3::Api.new(api_client.endpoint, username, desired.password).request(:get, '/service/metrics/ping')
+        password 'Supercalifragilisticexpialidocious-that-does-not-exist-so-maybe-the-resource-will-need-to-converge'
+      rescue ::Nexus3::ApiError
+        password desired.password
+      end
     end
   rescue LoadError, ::Nexus3::ApiError => e
     ::Chef::Log.warn "A '#{e.class}' occurred: #{e.message}"

--- a/test/fixtures/cookbooks/nexus3_resources_test/attributes/user.rb
+++ b/test/fixtures/cookbooks/nexus3_resources_test/attributes/user.rb
@@ -9,6 +9,5 @@ default['nexus3_resources_test']['user']['create']['update_with_properties']['la
 default['nexus3_resources_test']['user']['create']['update_with_properties']['first_name'] = 'first_blah'
 default['nexus3_resources_test']['user']['create']['update_with_properties']['email'] = 'bur@bla.h'
 default['nexus3_resources_test']['user']['create']['update_with_properties']['roles'] = %w[nx-anonymous nx-admin]
-# action :delete
+# action :delete (without password!)
 default['nexus3_resources_test']['user']['delete']['default']['username'] = 'bur'
-default['nexus3_resources_test']['user']['delete']['default']['password'] = 'secret'


### PR DESCRIPTION
The `password` property is required for the `:create` action but it is useless for the `:delete` one.
The former code used to read its value to load the current resource, this procedure should be skip when possible.