### PR TITLE
Add new nexus3.desired_heap_size attribute to ease JVM heap tuning

### DIFF
--- a/Policyfile.rb
+++ b/Policyfile.rb
@@ -12,6 +12,7 @@ cookbook 'nexus3_resources_test', path: 'test/fixtures/cookbooks/nexus3_resource
 
 # Test attributes
 default['nexus3_test']['connection_retries'] = 10
+default['nexus3']['desired_heap_size'] = '2G'
 default['nexus3']['api']['sensitive'] = false
 
 # Constraints for Chef 14 :(

--- a/README.md
+++ b/README.md
@@ -78,9 +78,10 @@ Downloads and installs the latest Nexus 3 Repository Manager OSS.
   Default `{ 'application-host': '0.0.0.0', 'application-port': '8081', 'nexus-args':
   '${jetty.etc}/jetty.xml,${jetty.etc}/jetty-http.xml,${jetty.etc}/jetty-requestlog.xml',
   'nexus-context-path': '/' }`.
+- `node['nexus3']['desired_heap_size']` - To easily configure the min & max heap size (JVM Xms & Xmx). Default `'4G'`.
 - `node['nexus3']['vmoptions_variables']` - A Hash of variables that are
   passed into a template file. Note that data directory will be injected into
-  the hash if it is not defined. Default `{ Xms: '1200M', Xmx: '1200M' }`.
+  the hash if it is not defined and Xms & Xmx variables are managed by `desired_heap_size`. Default `{ Xms: '4G', Xmx: '4G' }`.
 - `node['nexus3']['nofile_limit']` - Limit of open files available for the
   Nexus3 service in systemd. Default 65,536 as suggested by the Sonatype
   documentation on newer releases.

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -26,8 +26,17 @@ default['nexus3']['nofile_limit'] = 65_536
 # Ref:
 #   https://help.sonatype.com/repomanager3/installation/configuring-the-runtime-environment
 #   https://help.sonatype.com/repomanager3/system-requirements
-default['nexus3']['vmoptions_variables']['Xms4G'] = nil
-default['nexus3']['vmoptions_variables']['Xmx4G'] = nil
+default['nexus3']['desired_heap_size'] = '4G'
+
+on_attribute_update('nexus3', 'desired_heap_size') do |_precedence, _path, new_value, previous_value|
+  new_value ||= node.read('nexus3', 'desired_heap_size') # the block is yield on registration with no "new value"
+
+  rm_default('nexus3', 'vmoptions_variables', "Xms#{previous_value}")
+  rm_default('nexus3', 'vmoptions_variables', "Xmx#{previous_value}")
+  default['nexus3']['vmoptions_variables']["Xms#{new_value}"] = nil
+  default['nexus3']['vmoptions_variables']["Xmx#{new_value}"] = nil
+end
+
 default['nexus3']['vmoptions_variables']['XX:+HeapDumpOnOutOfMemoryError'] = nil
 default['nexus3']['vmoptions_variables']['XX:+UnlockDiagnosticVMOptions'] = nil
 default['nexus3']['vmoptions_variables']['XX:+UnsyncloadClass'] = nil

--- a/metadata.rb
+++ b/metadata.rb
@@ -11,7 +11,7 @@ version '4.2.0'
 chef_version '>= 12.14.34'
 
 depends 'ark'
-depends 'updatable-attributes'
+depends 'updatable-attributes', '>= 1.0.0'
 
 supports 'centos'
 supports 'debian'

--- a/spec/unit/attributes/default_spec.rb
+++ b/spec/unit/attributes/default_spec.rb
@@ -1,0 +1,18 @@
+require 'spec_helper'
+
+describe 'nexus3::default' do
+  context 'nexus3.desired_heap_size' do
+    let(:chef_run) do
+      ChefSpec::SoloRunner.new(platform: 'centos', version: CENTOS_VERSION, step_into: 'nexus3')
+                          .converge(described_recipe)
+    end
+
+    it 'controls the Xms & Xmx JVM variables' do
+      chef_run.node.default['nexus3']['desired_heap_size'] = '12G'
+      expect(chef_run.node['nexus3']['vmoptions_variables']).to include('Xms12G', 'Xmx12G')
+      chef_run.node.default['nexus3']['desired_heap_size'] = '8G'
+      expect(chef_run.node['nexus3']['vmoptions_variables']).not_to include('Xms12G', 'Xmx12G')
+      expect(chef_run.node['nexus3']['vmoptions_variables']).to include('Xms8G', 'Xmx8G')
+    end
+  end
+end


### PR DESCRIPTION
The nexus3.vmoptions_variables format does not provide an easy way to tune the JVMP heap size.
The new nexus3.desired_heap_size attribute wraps the logic to set the correct keys in nexus3.vmoptions_variables hash.