### PR TITLE
Add JVM option Djava.endorsed.dirs to fix NoClassDefFoundError

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -38,3 +38,4 @@ default['nexus3']['vmoptions_variables']['Dkaraf.base'] = '.'
 default['nexus3']['vmoptions_variables']['Dkaraf.home'] = '.'
 default['nexus3']['vmoptions_variables']['Dkaraf.startLocalConsole'] = false
 default['nexus3']['vmoptions_variables']['Djava.net.preferIPv4Stack'] = true
+default['nexus3']['vmoptions_variables']['Djava.endorsed.dirs'] = 'lib/endorsed'


### PR DESCRIPTION
Since Nexus3 version ~3.19, this JVM option is needed. It will fix this errors that are flooding the logs during nexus3 launch:

org.ops4j.pax.logging.pax-logging-api [Felix] ERROR : Bundle org.apache.felix.framework [0] EventDispatcher: Error during dispatch. (java.lang.NoClassDefFoundError: org/apache/karaf/specs/locator/OsgiLocator)

See: https://issues.sonatype.org/browse/NEXUS-21603