### PR TITLE
Allow to configure nexus's system user uid & gid

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -13,6 +13,8 @@ default['nexus3']['home'] = "#{node['nexus3']['path']}/nexus3"
 default['nexus3']['data'] = "#{node['nexus3']['path']}/sonatype-work/nexus3"
 # Nexus username (do not run as root)
 default['nexus3']['user'] = 'nexus'
+default['nexus3']['uid'] = nil
+default['nexus3']['gid'] = nil
 
 default['nexus3']['properties_variables']['application-port'] = '8081'
 default['nexus3']['properties_variables']['application-host'] = '0.0.0.0'

--- a/resources/default.rb
+++ b/resources/default.rb
@@ -1,6 +1,8 @@
 property :instance_name, String, name_property: true
 property :nexus3_user, [String, NilClass], default: lazy { node['nexus3']['user'] }
+property :nexus3_uid, [String, Integer, NilClass], default: lazy { node['nexus3']['uid'] }
 property :nexus3_group, [String, NilClass], default: lazy { node['nexus3']['group'] }
+property :nexus3_gid, [String, Integer, NilClass], default: lazy { node['nexus3']['gid'] }
 property :nexus3_password, String, sensitive: true, default: lazy { node['nexus3']['api']['password'] } # Admin password
 property :version, String, default: lazy { node['nexus3']['version'] }
 property :url, [String, NilClass], default: lazy { node['nexus3']['url'] }
@@ -18,16 +20,17 @@ property :outbound_proxy, [Hash, NilClass], sensitive: true, default: lazy { nod
 action :install do
   install_dir = ::File.join(new_resource.path, "nexus-#{new_resource.version}")
 
+  group new_resource.nexus3_group do
+    gid new_resource.nexus3_gid unless new_resource.nexus3_gid.nil?
+  end
+
   user new_resource.nexus3_user do
     comment 'Nexus 3 user'
+    group new_resource.nexus3_group
     home new_resource.nexus3_home
     manage_home false # is linked to install_dir below
     shell '/bin/bash'
-  end
-
-  group new_resource.nexus3_group do
-    members new_resource.nexus3_user
-    append true
+    uid new_resource.nexus3_uid unless new_resource.nexus3_uid.nil?
   end
 
   # Install Nexus3 software

--- a/test/fixtures/cookbooks/nexus3_test/recipes/default.rb
+++ b/test/fixtures/cookbooks/nexus3_test/recipes/default.rb
@@ -14,6 +14,8 @@ unless platform_family?('windows')
     data '/usr/local/nexusbar/data'
     nexus3_user 'nexusbar'
     nexus3_group 'nexusbar'
+    nexus3_uid 1234
+    nexus3_gid 5678
     nexus3_home '/home/nexusbar'
     nexus3_password 'humdiddle'
     properties_variables(node['nexus3']['properties_variables'].merge('application-port': '8082'))

--- a/test/integration/default/inspec/default_spec.rb
+++ b/test/integration/default/inspec/default_spec.rb
@@ -60,6 +60,13 @@ else # Linux
     its('content') { should match(%r{nexus-context-path=/}) }
   end
 
+  describe user('nexusbar') do
+    it { should exist }
+    its('uid') { should eq 1234 }
+    its('group') { should eq 'nexusbar' }
+    its('gid') { should eq 5678 }
+  end
+
   describe file('/usr/local/nexusbar/data/etc') do
     it { should be_directory }
     it { should be_owned_by 'nexusbar' }


### PR DESCRIPTION
It's better to give the ability to users to be very explicit on their desired configuration.
Especially on such property, which ease consistency of files ownership accross multiple installs.