### PR TITLE
Support plugins installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ Downloads and installs the latest Nexus 3 Repository Manager OSS.
   documentation on newer releases.
 - `node['nexus3']['outbound_proxy']` - Configure outbound HTTP/HTTPS proxy. See example
   'Configure outbound HTTP/HTTPS proxy for all the attributes.'
+- `node['nexus3']['plugins']` - Install external plugins, takes a hash of `{ 'plugin-name' : { "name": "name override", "source": "..", "checksum": "..", "action": "remote file action"}}`. Plugins should be bundled in KAR format, and will be written on disk as `<plugin-name>-bundle.kar`
 
 ### Examples
 

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -50,3 +50,15 @@ default['nexus3']['vmoptions_variables']['Dkaraf.home'] = '.'
 default['nexus3']['vmoptions_variables']['Dkaraf.startLocalConsole'] = false
 default['nexus3']['vmoptions_variables']['Djava.net.preferIPv4Stack'] = true
 default['nexus3']['vmoptions_variables']['Djava.endorsed.dirs'] = 'lib/endorsed'
+
+# Plugins bundles in KAR format to install
+#
+#  default['nexus3']['plugins']['nexus-repository-chef'] = {
+#    "name": "force_another_name",
+#    "source": "https://on.the.internet/nexus-repository-chef-0.0.10-bundle.kar",
+#    "checksum": "8e6494bd8edbf3beb6b7054d599561e698dcf3f666c2114b7126c246804484a9",
+#    "action": "create" # https://docs.chef.io/resources/remote_file/#actions
+#  }
+#
+# https://help.sonatype.com/en/installing-bundles.html
+default['nexus3']['plugins'] = {}


### PR DESCRIPTION
FAR: Install a plugin in tests, the one we have on hand for
     chef has some issues preventing us to create maven components.
     Until we've got a better/fixed plugin let's skip the install
     in tests.