### PR TITLE
[Breaking] bump the CI and minimal nexus version

### DIFF
--- a/.github/workflows/criteo-cookbooks-ci.yml
+++ b/.github/workflows/criteo-cookbooks-ci.yml
@@ -12,7 +12,7 @@ jobs:
   rspec:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: 2.7
@@ -27,9 +27,9 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        instance: ['default-centos-7', 'default-ubuntu-2004', 'default-fedora-29']
+        instance: ['default-centos-stream-8', 'default-ubuntu-2204', 'default-fedora-39']
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: 2.7
@@ -40,7 +40,7 @@ jobs:
     if: startsWith(github.ref, 'refs/tags/')
     needs: [kitchen]
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Publish to supermarket
       uses: afaundez/chef-supermarket-action@8cdbe1cccbe1ecd8685b2ea8f48780135bae7cee
       with:

--- a/.kitchen.docker.yml
+++ b/.kitchen.docker.yml
@@ -2,7 +2,7 @@
 ---
 driver:
   name: dokken
-  chef_version: 14.7.17
+  chef_version: 17.9.46
   privileged: true # because Docker and SystemD/Upstart
 
 transport:
@@ -16,26 +16,26 @@ verifier:
   name: inspec
 
 platforms:
-- name: centos-7
+- name: centos-stream-8
   driver:
-    image: dokken/centos-7
+    image: dokken/centos-stream-8
     intermediate_instructions:
       - RUN yum clean all
       - RUN yum -y install net-tools lsof
     pid_one_command: /usr/lib/systemd/systemd
 
-- name: fedora-29
+- name: fedora-39
   driver:
-    image: fedora:29
+    image: dokken/fedora-39
     intermediate_instructions:
     - RUN yum clean all
     pid_one_command: /usr/lib/systemd/systemd
     intermediate_instructions:
       - RUN yum -y install tar yum
 
-- name: ubuntu-20.04
+- name: ubuntu-22.04
   driver:
-    image: dokken/ubuntu-20.04
+    image: dokken/ubuntu-22.04
     pid_one_command: /bin/systemd
     intermediate_instructions:
       - RUN /usr/bin/apt-get update

--- a/Gemfile
+++ b/Gemfile
@@ -1,17 +1,17 @@
 source 'https://rubygems.org'
 
 group :unit_test do
-  gem 'chef', '= 14.7.17'
-  gem 'chefspec', '>= 9.2.1'
-  gem 'fakefs', '>= 2.4.0'
+  gem 'chef', '= 17.9.46'
+  gem 'chefspec', '>= 9.3.6'
+  gem 'fakefs', '>= 2.5.0'
   gem 'webmock', '>= 3.13.0'
 end
 
 group :integration do
-  gem 'kitchen-dokken', '>= 2.19.1'
-  gem 'kitchen-inspec', '>= 2.6.1'
-  gem 'kitchen-vagrant', '>= 1.14.1'
-  gem 'test-kitchen', '>= 3.5.0'
+  gem 'kitchen-dokken', '>= 2.20.3'
+  gem 'kitchen-inspec', '>= 2.6.2'
+  gem 'kitchen-vagrant', '>= 1.14.2'
+  gem 'test-kitchen', '>= 3.5.1'
 end
 
 group :lint do

--- a/Policyfile.rb
+++ b/Policyfile.rb
@@ -14,7 +14,3 @@ cookbook 'nexus3_resources_test', path: 'test/fixtures/cookbooks/nexus3_resource
 default['nexus3_test']['connection_retries'] = 10
 default['nexus3']['desired_heap_size'] = '2G'
 default['nexus3']['api']['sensitive'] = false
-
-# Constraints for Chef 14 :(
-cookbook 'ark', '= 5.1.1' # Drop constraint when requiring Chef >= 15
-cookbook 'homebrew', '= 5.3.1' # Drop constraint when requiring Chef >= 15

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -6,7 +6,7 @@ else
   default['nexus3']['group'] = 'nexus'
 end
 # Download URL is defined in the resource but you can override it with the default['nexus3']['url'] attribute
-default['nexus3']['version'] = '3.27.0-03'
+default['nexus3']['version'] = '3.64.0-04'
 default['nexus3']['url'] = nil # optional
 default['nexus3']['checksum'] = nil # optional
 default['nexus3']['home'] = "#{node['nexus3']['path']}/nexus3"

--- a/metadata.rb
+++ b/metadata.rb
@@ -6,9 +6,9 @@ description 'Installs/Configures Sonatype Nexus 3 Repository Manager'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 source_url 'https://github.com/criteo-cookbooks/chef-nexus3' if respond_to?(:source_url)
 issues_url 'https://github.com/criteo-cookbooks/chef-nexus3/issues' if respond_to?(:issues_url)
-version '4.3.0'
+version '5.0.0'
 
-chef_version '>= 12.14.34'
+chef_version '>= 17.9.46'
 
 depends 'ark'
 depends 'updatable-attributes', '>= 1.0.0'

--- a/resources/api.rb
+++ b/resources/api.rb
@@ -1,7 +1,7 @@
 property :script_name, String, name_property: true
 property :content, String, default: ''.freeze
 property :args, [Hash, String, NilClass], desired_state: false
-property :api_client, ::Nexus3::Api, identity: true, default: lazy { ::Nexus3::Api.default(node) }
+property :api_client, ::Nexus3::Api, identity: true, desired_state: false, default: lazy { ::Nexus3::Api.default(node) }
 
 load_current_value do |desired|
   begin

--- a/resources/cleanup_policy.rb
+++ b/resources/cleanup_policy.rb
@@ -3,7 +3,7 @@ property :format, ::String, default: 'raw'.freeze
 property :criteria, ::Hash, default: lazy { ::Mash.new }, coerce: proc { |c| c.is_a?(::Mash) ? c : ::Mash.new(c) }
 property :mode, ::String, default: 'delete'.freeze
 property :notes, ::String, default: ''.freeze
-property :api_client, ::Nexus3::Api, identity: true, default: lazy { ::Nexus3::Api.default(node) }
+property :api_client, ::Nexus3::Api, identity: true, desired_state: false, default: lazy { ::Nexus3::Api.default(node) }
 
 load_current_value do |desired|
   begin

--- a/resources/component.rb
+++ b/resources/component.rb
@@ -10,7 +10,7 @@ property :maven2_group_id, [NilClass, ::String], default: nil
 # raw specific params
 property :raw_directory, [NilClass, ::String], default: nil
 
-property :api_client, ::Nexus3::Api, identity: true, default: lazy { ::Nexus3::Api.default(node) }
+property :api_client, ::Nexus3::Api, identity: true, desired_state: false, default: lazy { ::Nexus3::Api.default(node) }
 
 action :create do
   validate!

--- a/resources/group.rb
+++ b/resources/group.rb
@@ -3,7 +3,7 @@ property :group_type, String, regex: /-group$/, default: 'maven2-group'
 property :repositories, Array, default: lazy { [] }
 property :attributes, Hash, default: lazy { ::Mash.new } # Not mandatory but strongly recommended in the generic case.
 property :online, [true, false], default: true
-property :api_client, ::Nexus3::Api, identity: true, default: lazy { ::Nexus3::Api.default(node) }
+property :api_client, ::Nexus3::Api, identity: true, desired_state: false, default: lazy { ::Nexus3::Api.default(node) }
 
 action :create do
   nexus3_repo new_resource.group_name do

--- a/resources/outbound_proxy.rb
+++ b/resources/outbound_proxy.rb
@@ -1,5 +1,5 @@
 property :config, Hash, default: lazy { ::Mash.new }, sensitive: true
-property :api_client, ::Nexus3::Api, identity: true, default: lazy { ::Nexus3::Api.default(node) }
+property :api_client, ::Nexus3::Api, identity: true, desired_state: false, default: lazy { ::Nexus3::Api.default(node) }
 
 load_current_value do
   begin

--- a/resources/realm.rb
+++ b/resources/realm.rb
@@ -1,6 +1,6 @@
 property :realm_name, String, name_property: true
 property :enable, [true, false], required: true
-property :api_client, ::Nexus3::Api, identity: true, default: lazy { ::Nexus3::Api.default(node) }
+property :api_client, ::Nexus3::Api, identity: true, desired_state: false, default: lazy { ::Nexus3::Api.default(node) }
 
 load_current_value do |desired|
   # By default, it will be 'false' if given realm not exist on server's side, then

--- a/resources/repo.rb
+++ b/resources/repo.rb
@@ -3,7 +3,7 @@ property :repo_type, String, default: 'maven2-hosted'
 property :attributes, Hash, coerce: ::Nexus3::Helper.method(:coerce_repo_attributes), default: lazy { ::Mash.new }
 property :online, [true, false], default: true
 property :routing_rule_name, String, default: ''
-property :api_client, ::Nexus3::Api, identity: true, default: lazy { ::Nexus3::Api.default(node) }
+property :api_client, ::Nexus3::Api, identity: true, desired_state: false, default: lazy { ::Nexus3::Api.default(node) }
 
 load_current_value do |desired|
   begin

--- a/resources/role.rb
+++ b/resources/role.rb
@@ -2,7 +2,7 @@ property :role_name, String, name_property: true
 property :description, String, default: ''.freeze
 property :roles, Array, default: lazy { [] }, coerce: proc { |r| r.sort }
 property :privileges, Array, default: lazy { [] }, coerce: proc { |p| p.sort }
-property :api_client, ::Nexus3::Api, identity: true, default: lazy { ::Nexus3::Api.default(node) }
+property :api_client, ::Nexus3::Api, identity: true, desired_state: false, default: lazy { ::Nexus3::Api.default(node) }
 
 load_current_value do
   begin

--- a/resources/routing_rule.rb
+++ b/resources/routing_rule.rb
@@ -2,7 +2,7 @@ property :rule_name, ::String, name_property: true
 property :description, ::String, default: ''.freeze
 property :mode, ::String, equal_to: %w[BLOCK ALLOW], default: 'BLOCK'.freeze
 property :matchers, Array, default: lazy { [] }, coerce: proc { |m| m.sort }
-property :api_client, ::Nexus3::Api, identity: true, default: lazy { ::Nexus3::Api.default(node) }
+property :api_client, ::Nexus3::Api, identity: true, desired_state: false, default: lazy { ::Nexus3::Api.default(node) }
 
 load_current_value do |desired|
   begin

--- a/resources/task.rb
+++ b/resources/task.rb
@@ -31,7 +31,7 @@ property :task_name, String, name_property: true
 property :task_type, String, equal_to: NEXUS3_TASK_TYPES
 property :properties, Hash, default: {}.freeze
 property :crontab, String, default: '0 1 * * * ?'.freeze
-property :api_client, ::Nexus3::Api, identity: true, default: lazy { ::Nexus3::Api.default(node) }
+property :api_client, ::Nexus3::Api, identity: true, desired_state: false, default: lazy { ::Nexus3::Api.default(node) }
 
 load_current_value do |desired|
   begin

--- a/resources/user.rb
+++ b/resources/user.rb
@@ -4,7 +4,7 @@ property :first_name, String, default: ''
 property :last_name, String, default: ''
 property :email, String, default: ''
 property :roles, Array, default: lazy { [] }, coerce: proc { |r| r.sort }
-property :api_client, ::Nexus3::Api, identity: true, default: lazy { ::Nexus3::Api.default(node) }
+property :api_client, ::Nexus3::Api, identity: true, desired_state: false, default: lazy { ::Nexus3::Api.default(node) }
 
 load_current_value do |desired|
   begin

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,8 +1,9 @@
 require 'chefspec'
 require 'chefspec/policyfile'
+require 'rexml/document'
 require 'webmock/rspec'
 
-VER = '3.27.0-03'.freeze
+VER = '3.64.0-04'.freeze
 CACHE = Chef::Config[:file_cache_path]
 CENTOS_VERSION = '7.8.2003'.freeze
 

--- a/test/fixtures/cookbooks/nexus3_resources_test/attributes/group.rb
+++ b/test/fixtures/cookbooks/nexus3_resources_test/attributes/group.rb
@@ -1,5 +1,5 @@
 # Test group resource
-default_repo_conf = ::Mash.new(storage: { blobStoreName: 'default', writePolicy: 'ALLOW_ONCE' })
+default_repo_conf = ::Mash.new(storage: { blobStoreName: 'default', writePolicy: 'ALLOW_ONCE' }, component: {})
 default_group_conf = ::Mash.new(storage: { blobStoreName: 'default', strictContentTypeValidation: true })
 
 # Create 2 pypi repo first

--- a/test/fixtures/cookbooks/nexus3_resources_test/attributes/repo.rb
+++ b/test/fixtures/cookbooks/nexus3_resources_test/attributes/repo.rb
@@ -1,7 +1,7 @@
 # Test repo resource
 default_repo_conf = ::Mash.new(storage: { blobStoreName: 'default', writePolicy: 'ALLOW_ONCE' })
-default_maven_conf = default_repo_conf.merge(maven: { versionPolicy: 'RELEASE', layoutPolicy: 'STRICT' })
-default_maven_proxy_conf = default_maven_conf.merge('maven-indexer': {}, proxy: { remoteUrl: 'http://localhost:8081' }, httpclient: {}, negativeCache: {})
+default_maven_conf = default_repo_conf.merge(maven: { versionPolicy: 'RELEASE', layoutPolicy: 'STRICT' }, component: {})
+default_maven_proxy_conf = default_maven_conf.merge('maven-indexer': {}, proxy: { remoteUrl: 'http://localhost:8081' }, httpclient: {}, negativeCache: {}, replication:{})
 #  action: create
 default['nexus3_resources_test']['repo']['create']['maven']['repo_name'] = 'foo_maven'
 default['nexus3_resources_test']['repo']['create']['maven']['repo_type'] = 'maven2-hosted'

--- a/test/fixtures/cookbooks/nexus3_resources_test/attributes/user.rb
+++ b/test/fixtures/cookbooks/nexus3_resources_test/attributes/user.rb
@@ -9,5 +9,6 @@ default['nexus3_resources_test']['user']['create']['update_with_properties']['la
 default['nexus3_resources_test']['user']['create']['update_with_properties']['first_name'] = 'first_blah'
 default['nexus3_resources_test']['user']['create']['update_with_properties']['email'] = 'bur@bla.h'
 default['nexus3_resources_test']['user']['create']['update_with_properties']['roles'] = %w[nx-anonymous nx-admin]
-# action :delete (without password!)
+# action :delete
 default['nexus3_resources_test']['user']['delete']['default']['username'] = 'bur'
+default['nexus3_resources_test']['user']['delete']['default']['password'] = 'deleteme'

--- a/test/fixtures/cookbooks/nexus3_test/attributes/default.rb
+++ b/test/fixtures/cookbooks/nexus3_test/attributes/default.rb
@@ -1,6 +1,3 @@
 default['nexus3']['api']['username'] = 'admin'
 default['nexus3']['api']['password'] = 'admin123'
 default['nexus3']['api']['endpoint'] = 'http://localhost:8081/service/rest/v1/'
-
-default['java']['install_flavor'] = 'openjdk'
-default['java']['jdk_version'] = '8'

--- a/test/fixtures/cookbooks/nexus3_test/metadata.rb
+++ b/test/fixtures/cookbooks/nexus3_test/metadata.rb
@@ -7,4 +7,4 @@ long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 version '0.1.0'
 
 depends 'nexus3'
-depends 'java', '= 7.0.0'
+depends 'java'

--- a/test/fixtures/cookbooks/nexus3_test/recipes/default.rb
+++ b/test/fixtures/cookbooks/nexus3_test/recipes/default.rb
@@ -1,4 +1,4 @@
-include_recipe 'java' unless platform_family?('windows')
+openjdk_pkg_install '8' unless platform_family?('windows')
 
 package 'curl'
 


### PR DESCRIPTION
- We now require Chef 17 and Nexus 3.64
- OS versions to use Centos 8, recent fedora and Ubuntu LTS 2204
- Github actions updated to recent versions