### PR TITLE
fix default api endpoint value

### DIFF
--- a/attributes/api.rb
+++ b/attributes/api.rb
@@ -1,6 +1,6 @@
 default['nexus3']['api']['script_cookbook'] = 'nexus3'
 default['nexus3']['api']['type'] = 'groovy'
-default['nexus3']['api']['endpoint'] = 'http://localhost:8081/service/rest/v1/script/'
+default['nexus3']['api']['endpoint'] = 'http://localhost:8081/service/rest/v1/'
 default['nexus3']['api']['username'] = 'admin'
 default['nexus3']['api']['password'] = 'admin123'
 default['nexus3']['api']['ignore_failure'] = true


### PR DESCRIPTION
/script/ is added wherever we need so we can still use the api for other things.

Helper libs and tests already got rid of the extra /script/

fixes #136