### PR TITLE
Allow to add nexus user to additional groups

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,9 +2,12 @@ source 'https://rubygems.org'
 
 group :unit_test do
   gem 'chef', '= 17.9.46'
-  gem 'chefspec', '>= 9.3.6'
   gem 'fakefs', '>= 2.5.0'
   gem 'webmock', '>= 3.13.0'
+
+  # TODO: Unpin chefspec and remove rspec pin once chefspec integrates breaking rspec-expectations change
+  gem 'chefspec', '= 9.3.6'
+  gem 'rspec-expectations', '= 3.12.3'
 end
 
 group :integration do

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -15,6 +15,9 @@ default['nexus3']['data'] = "#{node['nexus3']['path']}/sonatype-work/nexus3"
 default['nexus3']['user'] = 'nexus'
 default['nexus3']['uid'] = nil
 default['nexus3']['gid'] = nil
+# Additional groups to add nexus user to, for example when sharing a license file between users.
+# Groups listed must already exist.
+default['nexus3']['additional_groups'] = []
 
 default['nexus3']['properties_variables']['application-port'] = '8081'
 default['nexus3']['properties_variables']['application-host'] = '0.0.0.0'

--- a/resources/default.rb
+++ b/resources/default.rb
@@ -3,6 +3,7 @@ property :nexus3_user, [String, NilClass], default: lazy { node['nexus3']['user'
 property :nexus3_uid, [String, Integer, NilClass], default: lazy { node['nexus3']['uid'] }
 property :nexus3_group, [String, NilClass], default: lazy { node['nexus3']['group'] }
 property :nexus3_gid, [String, Integer, NilClass], default: lazy { node['nexus3']['gid'] }
+property :nexus3_additional_groups, [Array, NilClass], default: lazy { node['nexus3']['additional_groups'] }
 property :nexus3_password, String, sensitive: true, default: lazy { node['nexus3']['api']['password'] } # Admin password
 property :version, String, default: lazy { node['nexus3']['version'] }
 property :url, [String, NilClass], default: lazy { node['nexus3']['url'] }
@@ -32,6 +33,16 @@ action :install do
     manage_home false # is linked to install_dir below
     shell '/bin/bash'
     uid new_resource.nexus3_uid unless new_resource.nexus3_uid.nil?
+  end
+
+  new_resource.nexus3_additional_groups.to_a.each do |gr|
+    group "add #{new_resource.nexus3_user} user to #{gr} group" do
+      group_name gr
+      action :modify
+      append true
+      members [new_resource.nexus3_user]
+      not_if { platform?('windows') }
+    end
   end
 
   # Install Nexus3 software

--- a/test/fixtures/cookbooks/nexus3_test/recipes/default.rb
+++ b/test/fixtures/cookbooks/nexus3_test/recipes/default.rb
@@ -1,5 +1,7 @@
 openjdk_pkg_install '8' unless platform_family?('windows')
 
+group 'nexusall'
+
 package 'curl'
 
 # Installation with default settings
@@ -16,6 +18,7 @@ unless platform_family?('windows')
     nexus3_group 'nexusbar'
     nexus3_uid 1234
     nexus3_gid 5678
+    nexus3_additional_groups ['nexusall']
     nexus3_home '/home/nexusbar'
     nexus3_password 'humdiddle'
     properties_variables(node['nexus3']['properties_variables'].merge('application-port': '8082'))

--- a/test/integration/default/inspec/default_spec.rb
+++ b/test/integration/default/inspec/default_spec.rb
@@ -69,6 +69,7 @@ else # Linux
     it { should exist }
     its('uid') { should eq 1234 }
     its('group') { should eq 'nexusbar' }
+    its('groups') { should include 'nexusall' }
     its('gid') { should eq 5678 }
   end
 


### PR DESCRIPTION
This will allow to provide a license file to be used by different instances or a single one without the need to manage it directly in the nexus cookbook.