### PR TITLE
Add property to configure logback.xml

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -25,6 +25,8 @@ default['nexus3']['properties_variables']['nexus-args'] = '${jetty.etc}/jetty.xm
 default['nexus3']['properties_variables']['nexus-context-path'] = '/'
 default['nexus3']['properties_variables']['nexus.scripts.allowCreation'] = 'true'
 
+default['nexus3']['logback_variables'] = {}
+
 default['nexus3']['nofile_limit'] = 65_536
 
 # Nexus JVM tunning

--- a/resources/default.rb
+++ b/resources/default.rb
@@ -20,7 +20,7 @@ property :outbound_proxy, [Hash, NilClass], sensitive: true, default: lazy { nod
 property :plugins, Hash, default: lazy { node['nexus3']['plugins'] }
 property :logback_variables, Hash, default: lazy { node['nexus3']['logback_variables'] }
 
-action :install do
+action :install do # rubocop:disable Metrics/BlockLength
   install_dir = ::File.join(new_resource.path, "nexus-#{new_resource.version}")
 
   group new_resource.nexus3_group do

--- a/resources/default.rb
+++ b/resources/default.rb
@@ -18,6 +18,7 @@ property :properties_variables, Hash, default: lazy { node['nexus3']['properties
 property :vmoptions_variables, Hash, default: lazy { node['nexus3']['vmoptions_variables'] }
 property :outbound_proxy, [Hash, NilClass], sensitive: true, default: lazy { node['nexus3']['outbound_proxy'] }
 property :plugins, Hash, default: lazy { node['nexus3']['plugins'] }
+property :logback_variables, Hash, default: lazy { node['nexus3']['logback_variables'] }
 
 action :install do
   install_dir = ::File.join(new_resource.path, "nexus-#{new_resource.version}")
@@ -106,6 +107,17 @@ action :install do
     group new_resource.nexus3_group
     notifies :restart, "nexus3_service[#{new_resource.service_name}]", :delayed
     notifies :run, "ruby_block[#{blocker}]", :delayed
+  end
+
+  template ::File.join(new_resource.data, 'etc', 'logback', 'logback.xml') do
+    source new_resource.logback_variables['source']
+    cookbook new_resource.logback_variables['cookbook']
+    mode '0644'
+    owner new_resource.nexus3_user
+    group new_resource.nexus3_group
+    notifies :restart, "nexus3_service[#{new_resource.service_name}]", :delayed
+    notifies :run, "ruby_block[#{blocker}]", :delayed
+    not_if { new_resource.logback_variables.empty? }
   end
 
   # Install plugins

--- a/resources/default.rb
+++ b/resources/default.rb
@@ -115,6 +115,7 @@ action :install do # rubocop:disable Metrics/BlockLength
     mode '0644'
     owner new_resource.nexus3_user
     group new_resource.nexus3_group
+    variables(config: new_resource.logback_variables['config'])
     notifies :restart, "nexus3_service[#{new_resource.service_name}]", :delayed
     notifies :run, "ruby_block[#{blocker}]", :delayed
     not_if { new_resource.logback_variables.empty? }


### PR DESCRIPTION
* Users are already able to configure logback for custom logging options outside of the cookbook. The main drawback is the restart of nexus required to take the changes into account.
* Here we allow them to pass their options directly to the resource with a template file and the cookbook name, to apply the template in the same resource and notify the restart at the same time.
