### PR TITLE
Add support for license installation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ Gemfile.lock
 .kitchen/
 .kitchen.local.yml
 .bundle/
+bundle/

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -7,13 +7,13 @@ AllCops:
 Layout/LineLength:
   Max: 150
 
-Layout/MethodLength:
+Metrics/MethodLength:
   Max: 60
 
-Layout/AbcSize:
+Metrics/AbcSize:
   Max: 60
 
-Layout/BlockLength:
+Metrics/BlockLength:
   Max: 130
 
 Naming/FileName:

--- a/resources/license.rb
+++ b/resources/license.rb
@@ -1,0 +1,39 @@
+property :fingerprint, String, default: lazy { node['nexus3']['license_fingerprint'] }
+property :license, String, sensitive: true, default: lazy { node['nexus3']['license'] }
+property :api_client, ::Nexus3::Api, identity: true, desired_state: false, default: lazy { ::Nexus3::Api.default(node) }
+
+load_current_value do |_desired|
+  begin
+    config = api_client.request(:get, 'system/license')
+    current_value_does_not_exist! if config.nil?
+    fingerprint JSON.parse(config)['fingerprint']
+  # Nexus returns a 402 Payment Required when there is no license installed, we get an ApiError
+  rescue ::LoadError, ::Nexus3::ApiError => e
+    ::Chef::Log.warn "A '#{e.class}' occured: #{e.message}"
+    current_value_does_not_exist!
+  end
+end
+
+action :update do
+  converge_if_changed :fingerprint do
+    converge_by('Uploading license') do
+      new_resource.api_client.request(
+        :post, 'system/license', data: ::Base64.decode64(new_resource.license), content_type: 'application/octet-stream'
+      )
+    end
+  end
+end
+
+action :delete do
+  unless current_resource.nil?
+    converge_by('Unregistering license') do
+      new_resource.api_client.request(:delete, 'system/license')
+    end
+  end
+end
+
+action_class do
+  def whyrun_supported?
+    true
+  end
+end

--- a/spec/unit/resource_validation_spec.rb
+++ b/spec/unit/resource_validation_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe 'nexus3_resources_test::default' do
-  NON_TESTED_RESOURCES = %w[service_systemd service_windows default service_sysvinit].freeze
+  NON_TESTED_RESOURCES = %w[default license service_systemd service_sysvinit service_windows].freeze
   cached(:chef_run) do
     ::ChefSpec::SoloRunner.new(platform: 'centos', version: CENTOS_VERSION).converge(described_recipe)
   end


### PR DESCRIPTION
Via system property path so we do not require a restart on
new install or upgrade as the license will be directly loaded.
cf: https://help.sonatype.com/en/installing-and-updating-licenses.html#installing-or-updating-a-license-using-a-system-property

But also via the API directly for when the license needs
to be updated as the system property path does not care
about the license file being updated if a license is
already installed.