### PR TITLE
Fix loading current value for nexus user passwords

### DIFF
--- a/resources/user.rb
+++ b/resources/user.rb
@@ -19,10 +19,10 @@ load_current_value do |desired|
     # Check if we need to change the password.
     if self.class.properties[:password].is_set?(desired)
       begin
-        ::Nexus3::Api.new(api_client.endpoint, username, desired.password).request(:get, '/service/metrics/ping')
-        password 'Supercalifragilisticexpialidocious-that-does-not-exist-so-maybe-the-resource-will-need-to-converge'
-      rescue ::Nexus3::ApiError
+        ::Nexus3::Api.new(api_client.endpoint, username, desired.password).request(:get, '/service/rapture/session')
         password desired.password
+      rescue ::Nexus3::ApiError
+        password 'Supercalifragilisticexpialidocious-that-does-not-exist-so-maybe-the-resource-will-need-to-converge'
       end
     end
   rescue LoadError, ::Nexus3::ApiError => e

--- a/resources/user.rb
+++ b/resources/user.rb
@@ -19,7 +19,7 @@ load_current_value do |desired|
     # Check if we need to change the password.
     if self.class.properties[:password].is_set?(desired)
       begin
-        ::Nexus3::Api.new(api_client.endpoint, username, desired.password).request(:get, '/service/rapture/session')
+        ::Nexus3::Api.new(api_client.endpoint, username, desired.password).request(:get, 'status')
         password desired.password
       rescue ::Nexus3::ApiError
         password 'Supercalifragilisticexpialidocious-that-does-not-exist-so-maybe-the-resource-will-need-to-converge'

--- a/spec/unit/resources/user_spec.rb
+++ b/spec/unit/resources/user_spec.rb
@@ -43,7 +43,7 @@ describe 'nexus3_test::user' do
                    user_response('user_with_role'),
                    user_response('user_with_role'))
 
-      stub_request(:get, 'http://localhost:8081/service/metrics/ping')
+      stub_request(:get, 'http://localhost:8081/service/rapture/session')
         .to_return(api_response(200))
     end
 

--- a/spec/unit/resources/user_spec.rb
+++ b/spec/unit/resources/user_spec.rb
@@ -44,7 +44,10 @@ describe 'nexus3_test::user' do
                    user_response('user_with_role'))
 
       stub_request(:get, 'http://localhost:8081/service/rest/v1/status')
-        .to_return(api_response(200))
+        .to_return(api_response(200)) # Nominal case
+      stub_request(:get, 'http://localhost:8081/service/rest/v1/status')
+        .with(basic_auth: %w[test-with-pass newpassword])
+        .to_return(api_response(401)) # When password is changed
     end
 
     it 'creates a user' do

--- a/spec/unit/resources/user_spec.rb
+++ b/spec/unit/resources/user_spec.rb
@@ -43,7 +43,7 @@ describe 'nexus3_test::user' do
                    user_response('user_with_role'),
                    user_response('user_with_role'))
 
-      stub_request(:get, 'http://localhost:8081/service/rapture/session')
+      stub_request(:get, 'http://localhost:8081/service/rest/v1/status')
         .to_return(api_response(200))
     end
 


### PR DESCRIPTION
There's two issues solved by this commit:

- The API calls to check if the new password works always failed;
- The new password was given as the old password value when the call failed, making it impossible to update the password.