### PR TITLE
Fix CI errors with centos-stream-8 kitchen suite

### DIFF
--- a/.kitchen.docker.yml
+++ b/.kitchen.docker.yml
@@ -21,7 +21,6 @@ platforms:
     image: dokken/centos-stream-8
     intermediate_instructions:
       - RUN yum clean all
-      - RUN yum -y install net-tools lsof
     pid_one_command: /usr/lib/systemd/systemd
 
 - name: fedora-39

--- a/.kitchen.docker.yml
+++ b/.kitchen.docker.yml
@@ -18,7 +18,7 @@ verifier:
 platforms:
 - name: centos-stream-8
   driver:
-    image: dokken/centos-stream-8
+    image: dokken/centos-stream-8:sha-f885abd
     intermediate_instructions:
       - RUN dnf clean all
       - RUN dnf -y install net-tools lsof

--- a/.kitchen.docker.yml
+++ b/.kitchen.docker.yml
@@ -19,8 +19,6 @@ platforms:
 - name: centos-stream-8
   driver:
     image: dokken/centos-stream-8
-    intermediate_instructions:
-      - RUN yum clean all
     pid_one_command: /usr/lib/systemd/systemd
 
 - name: fedora-39

--- a/.kitchen.docker.yml
+++ b/.kitchen.docker.yml
@@ -18,8 +18,10 @@ verifier:
 platforms:
 - name: centos-stream-8
   driver:
-    image: dokken/centos-stream-8:sha-f885abd
+    image: dokken/centos-stream-8
     intermediate_instructions:
+      - RUN sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-*
+      - RUN sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-*
       - RUN dnf clean all
       - RUN dnf -y install net-tools lsof
     pid_one_command: /usr/lib/systemd/systemd

--- a/.kitchen.docker.yml
+++ b/.kitchen.docker.yml
@@ -19,6 +19,9 @@ platforms:
 - name: centos-stream-8
   driver:
     image: dokken/centos-stream-8
+    intermediate_instructions:
+      - RUN dnf clean all
+      - RUN dnf -y install net-tools lsof
     pid_one_command: /usr/lib/systemd/systemd
 
 - name: fedora-39


### PR DESCRIPTION
centos-stream-8 has reached EoL and its packages are now found at vault.centos.org, leading to failures running the kitchen suite default-centos-stream-8.

As the dokken image does not seem to reflect this change yet, we change the baseurl for the CentOS repos to the correct new URL when we set up the image for the kitchen suite.