### PR TITLE
Fix & centralize the json parsing of the scripts executions

### DIFF
--- a/libraries/api.rb
+++ b/libraries/api.rb
@@ -67,6 +67,11 @@ module Nexus3
       JSON.parse(body)['result']
     end
 
+    def run_json_script(scriptname, params)
+      result = run_script(scriptname, params)
+      [nil, '', 'null'].include?(result) ? nil : JSON.parse(result)
+    end
+
     # Define rest methods to get and updates resources.
     # single and many are used to name ruby methods.
     [

--- a/resources/cleanup_policy.rb
+++ b/resources/cleanup_policy.rb
@@ -7,7 +7,7 @@ property :api_client, ::Nexus3::Api, identity: true, desired_state: false, defau
 
 load_current_value do |desired|
   begin
-    config = ::JSON.parse(api_client.run_script('get_cleanup_policy', desired.policy_name))
+    config = api_client.run_json_script('get_cleanup_policy', desired.policy_name)
     current_value_does_not_exist! if config.nil?
     ::Chef::Log.debug "Config is: #{config}"
     criteria ::Mash.new(config['criteria'])

--- a/resources/outbound_proxy.rb
+++ b/resources/outbound_proxy.rb
@@ -3,7 +3,7 @@ property :api_client, ::Nexus3::Api, identity: true, desired_state: false, defau
 
 load_current_value do
   begin
-    cfg = ::JSON.parse(api_client.run_script('get_outbound_proxy', nil))
+    cfg = api_client.run_json_script('get_outbound_proxy', nil)
     current_value_does_not_exist! if !cfg.respond_to?(:empty?) || cfg.empty?
     config cfg
     ::Chef::Log.debug "Config is: #{config}"

--- a/resources/repo.rb
+++ b/resources/repo.rb
@@ -7,7 +7,7 @@ property :api_client, ::Nexus3::Api, identity: true, desired_state: false, defau
 
 load_current_value do |desired|
   begin
-    config = ::JSON.parse(api_client.run_script('get_repo', desired.repo_name))
+    config = api_client.run_json_script('get_repo', desired.repo_name)
     current_value_does_not_exist! if config.nil?
     ::Chef::Log.debug "Config is: #{config}"
     repo_name config['repositoryName']

--- a/resources/role.rb
+++ b/resources/role.rb
@@ -6,7 +6,7 @@ property :api_client, ::Nexus3::Api, identity: true, desired_state: false, defau
 
 load_current_value do
   begin
-    config = ::JSON.parse(api_client.run_script('get_role', role_name))
+    config = api_client.run_json_script('get_role', role_name)
     current_value_does_not_exist! if config.nil?
     ::Chef::Log.debug "Role config is #{config}"
     description config['description']

--- a/resources/task.rb
+++ b/resources/task.rb
@@ -35,7 +35,7 @@ property :api_client, ::Nexus3::Api, identity: true, desired_state: false, defau
 
 load_current_value do |desired|
   begin
-    config = ::JSON.parse(api_client.run_script('get_task', desired.task_name))
+    config = api_client.run_json_script('get_task', desired.task_name)
     current_value_does_not_exist! if config.nil?
     ::Chef::Log.debug "Config is: #{config}"
     crontab config.dig('schedule', 'cronExpression') || ''.freeze

--- a/resources/user.rb
+++ b/resources/user.rb
@@ -8,7 +8,7 @@ property :api_client, ::Nexus3::Api, identity: true, desired_state: false, defau
 
 load_current_value do |desired|
   begin
-    config = ::JSON.parse(api_client.run_script('get_user', username))
+    config = api_client.run_json_script('get_user', username)
     current_value_does_not_exist! if config.nil?
     ::Chef::Log.debug "User config is #{config}"
     first_name config['first_name']


### PR DESCRIPTION
With recent nexus version the JSON lib seems to have change and the output of "ToJson" may return an empty string where it used to return a null value before.

This commit uses a centralized run_json_script to manage this case for all resources.