### PR TITLE
fix license update in multi instance context

### DIFF
--- a/resources/default.rb
+++ b/resources/default.rb
@@ -220,6 +220,7 @@ action :install do # rubocop:disable Metrics/BlockLength
     action :nothing
     fingerprint new_resource.license_fingerprint
     license new_resource.license
+    api_client(lazy { ::Nexus3::Api.local(port, 'admin', new_resource.nexus3_password) })
   end
 end
 


### PR DESCRIPTION
Without providing the api client to the nexus3_license resource we are always checking/updating the instance on the default port instead of the actual target instance running on a different port.